### PR TITLE
feat: ig write verbs — agent-ergonomic write path (new/edit/commit/validate/set/relate/unrelate)

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ ig search [--type T] [--by PK]  # Search objects
 ig inbound <ref> [--relation R]  # Inbound relations
 ig verify <file.json>            # Verify signature
 ig sign <spec.json>              # Sign spec, print envelope
-ig create <spec.json>            # Sign and publish
+ig create <spec.json>            # Sign and publish (full spec)
 ig auth                          # Hub authentication
 ig identity                      # Show current identity
 ig identity generate [--name N]  # Generate new identity
@@ -94,11 +94,39 @@ ig server                        # Show server status
 ig server set <url>              # Connect to hub
 ig server remove                 # Go offline
 ig server push                   # Push all local objects
+ig server push --ref <ref>       # Push one object
 ig realm                         # Show current realm
 ig realm set dataverse001        # Public realm
 ig realm set identity            # Private realm
 ig realm set <realm>             # Custom realm
 ```
+
+### Write verbs
+
+An agent-ergonomic write path with forced, synchronous, message-carrying
+feedback — you don't re-emit a whole document to change one field, and every
+error tells you what to do next. See the [tutorial](./TUTORIAL.md#9-editing-without-re-emitting-the-write-verbs).
+
+```bash
+ig new <type-ref>                # Scaffold a draft spec from a TYPE's schema
+ig edit <ref>                    # Check out an object for editing (conflict-safe)
+ig commit <draft.json>           # Validate + sign + publish a draft
+ig commit <spec.json> --update <ref>  # Deep-MERGE onto <ref> (omitted fields kept)
+ig validate <draft.json>         # Dry-run: run every check, change nothing
+ig set <ref> <path> [value]      # Patch one field (--json, --delete)
+ig relate <ref> <rel> <target>   # Add a relation (new signed revision)
+ig unrelate <ref> <rel> <target> # Remove a relation
+```
+
+Exit codes: `0` ok · `1` validation/parse/semantic · `2` usage · `3` revision
+conflict · `4` stored-locally-but-push-failed. Diagnostics go to stderr
+(prefixed `error:`); stdout carries only the result line.
+
+> **`ig create --update` vs `ig commit --update`.** `create --update` **replaces**
+> the object from a full spec (omitted top-level fields are wiped — preserving only
+> `id`/`created_at`). `commit --update` **deep-merges** a partial spec onto the
+> latest revision, so omitted fields are kept. Reach for `ig set` / `ig commit
+> --update` when you only want to change part of an object.
 
 ## Architecture
 
@@ -110,7 +138,10 @@ src/
   object.js         # buildItem, tombstone, parseRef, makeRef, isEnvelope
   identity.js       # deriveKeypair (PBKDF2), importPEM, createSigner
   validation.js     # JSON Schema validation for TYPE objects
-  client.js         # createClient — high-level API
+  scaffold.js       # schema → draft-spec scaffolding (ig new)
+  patch-ops.js      # field/relation mutations (ig set/relate/unrelate)
+  draft.js          # draft parsing + envelope checks (ig commit/validate)
+  client.js         # createClient — high-level API (incl. buildUpdate)
   store/
     hub.js          # createHubStore — HTTP hub backend
     fs.js           # createFsStore — filesystem (Node only)

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -225,7 +225,78 @@ Now anyone can find your reply by querying inbound relations on the original pos
 ig inbound AxyU5_...f47ac10b-... --relation replies_to
 ```
 
-## 9. Verify a signed object
+## 9. Editing without re-emitting: the write verbs
+
+So far you've written objects by handing `ig create` a whole spec. To *change* an
+object that way you'd re-emit the entire document — and the update path
+**replaces** it, silently wiping any top-level field you forgot to include. The
+write verbs fix that: they carry synchronous, specific feedback (every error
+tells you what to do next), and they let you change one field without re-typing
+the rest.
+
+**Scaffold a draft from a TYPE.** `ig new` reads the TYPE's schema and writes a
+draft with the required fields stubbed, so you don't hand-type the envelope:
+
+```bash
+ig new <type-ref>
+# drafts/NOTE-20260707-120000.json
+```
+
+Edit the placeholders in that file, then commit it:
+
+```bash
+ig commit drafts/NOTE-20260707-120000.json
+# committed AxyU5_...a1b2c3d4-... rev 0 (pushed)
+```
+
+`ig commit` validates against the TYPE schema, checks the envelope for typos,
+signs, stores, and pushes — failing fast with a specific message if anything is
+off. Want to check *without* writing anything? `ig validate <draft>` (an alias
+for `ig commit --dry-run`) runs every check and changes nothing.
+
+**Change one field.** No draft needed:
+
+```bash
+ig set <ref> content.title "A better title"      # string value
+ig set <ref> content.pinned true --json          # typed value (number/bool/array/object)
+ig set <ref> content.draft --delete              # remove a key
+# committed <ref> rev 1 (pushed)
+```
+
+**Add or remove a relation** (each is a new signed revision):
+
+```bash
+ig relate <ref> replies_to <other-ref> --instruction "in reply to"
+ig unrelate <ref> replies_to <other-ref>
+```
+
+**Merge, don't replace.** To update part of an existing object from a partial
+spec — keeping the fields you omit — use `ig commit --update`:
+
+```bash
+echo '{ "content": { "title": "v2" } }' > patch.json
+ig commit patch.json --update <ref>   # name, other content fields, etc. are preserved
+```
+
+(Contrast `ig create --update`, which replaces the whole document.)
+
+**Concurrency-safe editing.** For a bigger edit, check the object out first:
+
+```bash
+ig edit <ref>            # writes drafts/<ref>.json, recording the base revision
+# ...edit the draft...
+ig commit drafts/<ref>.json
+```
+
+If someone else updated the object while you were editing, `ig commit` refuses
+with a revision conflict (exit code 3) instead of clobbering their change — just
+`ig edit` again to pick up the latest.
+
+Exit codes across all write verbs: `0` success, `1` validation/parse error,
+`2` usage error, `3` revision conflict, `4` stored locally but the hub push
+failed (retry with `ig server push --ref <ref>`).
+
+## 10. Verify a signed object
 
 Got an InstructionGraph JSON file from somewhere? Verify its signature:
 
@@ -239,7 +310,7 @@ Verified OK
 
 This checks the ECDSA signature against the pubkey embedded in the object — no network needed.
 
-## 10. Going back offline
+## 11. Going back offline
 
 Don't need the server anymore? Disconnect:
 

--- a/cli/ig.js
+++ b/cli/ig.js
@@ -16,7 +16,7 @@
  */
 
 import { readFileSync, writeFileSync, existsSync, mkdirSync, readdirSync, unlinkSync } from 'node:fs'
-import { resolve, join, basename, dirname } from 'node:path'
+import { resolve, join, dirname } from 'node:path'
 import { canonicalJSON } from '../src/canonical.js'
 import { verify } from '../src/crypto.js'
 import { isEnvelope } from '../src/object.js'
@@ -64,7 +64,13 @@ function positionals(argv, valueFlags = []) {
   return out
 }
 
+// When a write verb (new/edit/commit/…) is running, shared helpers (die,
+// validateFlags, makeClient) must honour the write-verb error contract:
+// `error:`-prefixed stderr and exit 2 for usage/config errors.
+let writeVerbActive = false
+
 function die(msg) {
+  if (writeVerbActive) { writeErr(msg); process.exit(2) }
   console.error(`Error: ${msg}`)
   process.exit(1)
 }
@@ -978,6 +984,7 @@ function failWrite(msg, code = 1) { writeErr(msg); process.exit(code) }
 
 /** Run a write-verb handler, mapping any unexpected throw to an `error:` line. */
 async function runWrite(fn) {
+  writeVerbActive = true // shared helpers (die/validateFlags/makeClient) now use the write-verb contract
   try { await fn() }
   catch (e) { writeErr(e.message); process.exit(e.exitCode ?? 1) }
 }
@@ -1043,7 +1050,8 @@ async function ensureAuthForPush(ctx, realms) {
   if (readConfig(ctx.configDir, 'auth-token', null)) return
   writeNote('authenticating to push to identity realm…')
   const result = await ctx.client.authenticate()
-  if (!result.ok) failWrite('authentication failed — cannot push to identity realm.', 4)
+  // Nothing is signed or stored yet, so this is not the exit-4 "stored locally" case.
+  if (!result.ok) failWrite("could not authenticate to push to the identity realm. run 'ig server login' first.", 1)
   writeConfig(ctx.configDir, 'auth-token', result.token)
 }
 
@@ -1063,7 +1071,11 @@ async function publishItem(ctx, item, { requirePush = false, noPush = false } = 
   }
 
   const res = await ctx.client.publish(signed)
-  if (!res.ok) failWrite(`could not store object: ${res.error || `status ${res.status}`}`, 1)
+  if (!res.ok) {
+    // A revision clash here means the object moved under us between load and save.
+    failWrite([`could not store object: ${res.error || `status ${res.status}`}`,
+      're-run the command to rebuild the change on the latest revision.'], 1)
+  }
   // Sync store reports the true push outcome via _remoteOk. A hub-only store
   // (no local data dir) has no _remoteOk — a successful put there IS the push.
   // An offline fs store is never pushed.
@@ -1078,12 +1090,17 @@ async function publishItem(ctx, item, { requirePush = false, noPush = false } = 
   return { ref: item.ref, revision, pushed }
 }
 
-/** Print the one-line success result and consume the draft if it lived under drafts/. */
+/**
+ * Print the one-line success result and consume the draft — but only if it is
+ * the tool's own scratch draft (directly under ./drafts, where `ig new`/`ig edit`
+ * put it). Never delete an arbitrary file the user happens to point us at.
+ */
 function reportCommitted(res, draftFile) {
   console.log(`committed ${res.ref} rev ${res.revision} (${res.pushed ? 'pushed' : 'local-only'})`)
   if (draftFile) {
     const p = resolve(draftFile)
-    if (basename(dirname(p)) === 'drafts' && existsSync(p)) {
+    const ownDraftsDir = resolve(process.cwd(), 'drafts')
+    if (dirname(p) === ownDraftsDir && existsSync(p)) {
       try { unlinkSync(p) } catch { /* leave it if we can't remove it */ }
     }
   }
@@ -1109,7 +1126,9 @@ async function cmdNew() {
   }
 
   const draft = buildDraft({ typeObj, typeRef, identityName, realm })
-  const typeName = typeObj.item.content?.name || 'draft'
+  // Sanitize the TYPE name before using it in a filename — it comes from a fetched
+  // object and could contain path separators (e.g. "../../evil").
+  const typeName = String(typeObj.item.content?.name || 'draft').replace(/[^A-Za-z0-9._-]/g, '_').replace(/^\.+/, '') || 'draft'
   const path = allocDraftPath(flag('out'), `${typeName}-${draftTimestamp()}.json`)
   writeFileSync(path, JSON.stringify(draft, null, 2) + '\n')
   console.log(path)
@@ -1180,10 +1199,6 @@ async function cmdCommit({ forceDryRun = false } = {}) {
   // 2. Extract _draft (stripped from the payload — never signed)
   const { draft, payload } = extractDraft(parsed)
 
-  // 4. Envelope checks (unknown / signature-managed top-level fields)
-  const envErrors = envelopeErrors(payload)
-  if (envErrors.length) failWrite(envErrors, 1)
-
   // 3. Resolve identity / realm (flag > _draft > fallback), surfacing fallbacks
   const configDir = findConfigDir()
   const activeIdentity = readConfig(configDir, 'active-identity', 'default')
@@ -1195,6 +1210,15 @@ async function cmdCommit({ forceDryRun = false } = {}) {
   const realm = await resolveRealmAlias(target.realm, configDir, target.identity)
   if (target.realmSource === 'fallback') writeNote(`using default realm: ${realm ?? '(identity realm — private)'}`)
 
+  // 4. Envelope checks (unknown / signature-managed top-level fields)
+  const envErrors = envelopeErrors(payload)
+  if (envErrors.length) failWrite(envErrors, 1)
+
+  // The author relation is signature-managed — never take it from a draft.
+  // (new: rebuilt by client.build; merge: preserved from the original;
+  //  checkout: restored from the original in the patch fn below.)
+  if (payload.relations && 'author' in payload.relations) delete payload.relations.author
+
   const identityName = target.identitySource === 'fallback' ? undefined : target.identity
   const ctx = await makeClient({ identityName, realm })
   if (!ctx.client.signer) failWrite("no identity configured. run 'ig identity generate' first.", 2)
@@ -1203,8 +1227,15 @@ async function cmdCommit({ forceDryRun = false } = {}) {
   // Explicit --realm overrides the object's realm regardless of mode.
   if (target.realmSource === 'flag' && realm) payload.in = [realm]
 
-  // 5. Route by mode
+  // 5. Route by mode. --update (explicit merge target) beats a _draft mode,
+  // but a checkout draft + --update is a contradiction — refuse it.
   const updateRef = flag('update')
+  if (updateRef && draft?.mode === 'checkout') {
+    failWrite([
+      'this draft was checked out with `ig edit` (a full-document update).',
+      'drop --update to commit the checkout, or pass a bare spec (not a checkout draft) with --update to merge.'
+    ], 2)
+  }
   const mode = updateRef ? 'merge' : (draft?.mode === 'checkout' ? 'checkout' : 'new')
 
   let item, wouldMsg
@@ -1227,6 +1258,9 @@ async function cmdCommit({ forceDryRun = false } = {}) {
         for (const k of ['type', 'name', 'instruction', 'content', 'relations', 'in', 'rights']) {
           if (payload[k] !== undefined) next[k] = payload[k]
         }
+        // Never let a checkout drop the realm (would orphan the object) or the author.
+        if (next.in === undefined) next.in = orig.in
+        if (orig.relations?.author) next.relations = { ...(next.relations || {}), author: orig.relations.author }
         return next
       })
     } catch (e) { return failWrite(e.message, 1) }
@@ -1244,6 +1278,12 @@ async function cmdCommit({ forceDryRun = false } = {}) {
     catch (e) { return failWrite(e.message, 1) }
     item = built.item
     wouldMsg = `would update ${updateRef}`
+  }
+
+  // Every object must belong to a realm — a missing/empty `in` would make it
+  // invisible even to its owner and bypass the identity-realm push gate.
+  if (!Array.isArray(item.in) || item.in.length === 0) {
+    failWrite("the object has no realm — keep the 'in' field, or pass --realm.", 1)
   }
 
   // 6. Schema validation · 7. Relation shape checks
@@ -1265,8 +1305,14 @@ async function cmdCommit({ forceDryRun = false } = {}) {
 async function cmdSet() {
   const valueFlags = ['identity']
   validateFlags('set', args.slice(1), { booleanFlags: ['json', 'delete'], valueFlags })
-  const [ref, path, rawValue] = positionals(args.slice(1), valueFlags)
+  const pos = positionals(args.slice(1), valueFlags)
+  const [ref, path, rawValue] = pos
   if (!ref || !path) failWrite('usage: ig set <ref> <path> [<value>] [--json] [--delete] [--identity N]', 2)
+  // Guard against silent truncation of an unquoted multi-word value.
+  if (pos.length > 3) {
+    failWrite([`too many arguments — got ${pos.length - 2} value tokens after the path.`,
+      'quote the value if it contains spaces, e.g. ig set <ref> content.title "Two words".'], 2)
+  }
 
   const isDelete = args.includes('--delete')
   const isJson = args.includes('--json')
@@ -1325,6 +1371,8 @@ async function cmdRelate() {
   } catch (e) { return failWrite(e.message, 1) }
 
   await validateOrFail(ctx, built.item)
+  const relErrors = relationRefErrors(built.item)
+  if (relErrors.length) failWrite(relErrors, 1)
   const res = await publishItem(ctx, built.item, {})
   reportCommitted(res)
 }
@@ -1349,6 +1397,8 @@ async function cmdUnrelate() {
   } catch (e) { return failWrite(e.message, 1) }
 
   await validateOrFail(ctx, built.item)
+  const relErrors = relationRefErrors(built.item)
+  if (relErrors.length) failWrite(relErrors, 1)
   const res = await publishItem(ctx, built.item, {})
   reportCommitted(res)
 }

--- a/cli/ig.js
+++ b/cli/ig.js
@@ -16,7 +16,7 @@
  */
 
 import { readFileSync, writeFileSync, existsSync, mkdirSync, readdirSync, unlinkSync } from 'node:fs'
-import { resolve, join } from 'node:path'
+import { resolve, join, basename, dirname } from 'node:path'
 import { canonicalJSON } from '../src/canonical.js'
 import { verify } from '../src/crypto.js'
 import { isEnvelope } from '../src/object.js'
@@ -26,6 +26,9 @@ import { createFsStore } from '../src/store/fs.js'
 import { createSyncStore } from '../src/store/sync.js'
 import { isVisible, loadSharedRealms } from '../src/store/realm-filter.js'
 import { generateKeypair } from '../src/crypto.js'
+import { buildDraft } from '../src/scaffold.js'
+import { parseDraftJSON, extractDraft, envelopeErrors, resolveCommitTarget } from '../src/draft.js'
+import { setAtPath, deleteAtPath, addRelation, removeRelation, relationRefErrors } from '../src/patch-ops.js'
 
 const args = process.argv.slice(2)
 const cmd = args[0]
@@ -113,6 +116,16 @@ Commands:
   ig verify <file.json>            Verify signature
   ig sign <spec.json> [--identity N]  Sign spec, print envelope
   ig create <spec.json> [options]  Sign and publish
+
+Write verbs (agent-ergonomic, message-carrying):
+  ig new <type-ref> [options]      Scaffold a draft spec from a TYPE
+  ig edit <ref> [options]          Check out an object for editing
+  ig commit <draft.json> [options] Validate + sign + publish a draft
+  ig validate <draft.json> [opts]  Dry-run: validate a draft, change nothing
+  ig set <ref> <path> [value]      Patch one field (--json, --delete)
+  ig relate <ref> <rel> <target>   Add a relation (new signed revision)
+  ig unrelate <ref> <rel> <target> Remove a relation
+
   ig identity                      Show current identity
   ig identity generate [--name N]  Generate a new identity
                        [--project]  Use ./.instructionGraph instead of ~/
@@ -142,10 +155,18 @@ function commandUsage(command) {
     inbound: `Usage: ig inbound <ref> [--relation R] [--type T] [--from PK] [--limit N] [--cursor C] [--identity N] [--counts] [--jsonl] [--raw] [--local] [--remote]\n\nList objects that point to the target ref.\n\nFlags:\n  --relation R  Filter by relation name\n  --type T      Filter by source object type\n  --from PK     Filter by source object pubkey\n  --limit N     Max results (default: 20)\n  --cursor C    Pagination cursor from previous result\n  --identity N  Authenticate as identity N to access private objects\n  --counts      Include inbound relation counts\n  --jsonl       Output one JSON envelope per line (JSONL)\n  --raw         Skip realm filtering (show objects from any realm)\n  --local       Search local store only (skip hub)\n  --remote      Search hub only (skip local)`,
     verify: `Usage: ig verify <file.json>\n\nVerify an instructionGraph001 envelope on disk.`,
     sign: `Usage: ig sign <spec.json> [--identity N]\n\nBuild and sign a spec, then print the canonical envelope JSON.\n\nFlags:\n  --identity N  Sign with identity N instead of active identity`,
-    create: `Usage: ig create <spec.json> [--update] [--identity N] [--realm R] [--push] [--no-push]\n\nBuild, sign, and publish a spec to the configured store.\n\nSpec format (JSON):\n  All fields are optional. Auto-filled: id, pubkey, ref, in, created_at,\n  relations.author. Recommended:\n    type         Object type (e.g. POST, NOTE, COMMENT)\n    name         Short human-readable label\n    instruction  How agents should interpret/display this object\n    content      Free-form payload (e.g. { "title": "...", "body": "..." })\n  Other fields:\n    id           UUID (auto-generated if omitted)\n    in           Realm array (default: your active realm)\n    relations    Named arrays of { ref } links to other objects\n    rights       { license, ai_training_allowed }\n\n  The instruction field is key — it makes objects self-describing so any\n  agent (human or LLM) can understand them without external docs.\n\n  If using a type, add a type_def relation so the schema is validated:\n    "relations": { "type_def": [{ "ref": "<pubkey>.<type-uuid>" }] }\n\n  Structural objects should include a root relation for discoverability:\n    "relations": { "root": [{ "ref": "AxyU5_...00000000-...",\n      "url": "https://dataverse001.net/AxyU5_...00000000-..." }] }\n\nExample:\n  {\n    "type": "POST",\n    "name": "Hello",\n    "instruction": "A post. Display title and body.",\n    "content": { "title": "Hello!", "body": "First post!" }\n  }\n\nFlags:\n  --update      Allow updating existing objects (auto-increments revision,\n                sets updated_at). Without this, fails if object exists.\n  --identity N  Sign with identity N instead of active identity\n  --realm R     Override default realm (e.g. dataverse001, identity)\n  --push        Push to server (auto-login if needed for identity realm)\n  --no-push     Store locally only, skip server push`,
+    create: `Usage: ig create <spec.json> [--update] [--identity N] [--realm R] [--push] [--no-push]\n\nBuild, sign, and publish a spec to the configured store.\n\nSpec format (JSON):\n  All fields are optional. Auto-filled: id, pubkey, ref, in, created_at,\n  relations.author. Recommended:\n    type         Object type (e.g. POST, NOTE, COMMENT)\n    name         Short human-readable label\n    instruction  How agents should interpret/display this object\n    content      Free-form payload (e.g. { "title": "...", "body": "..." })\n  Other fields:\n    id           UUID (auto-generated if omitted)\n    in           Realm array (default: your active realm)\n    relations    Named arrays of { ref } links to other objects\n    rights       { license, ai_training_allowed }\n\n  The instruction field is key — it makes objects self-describing so any\n  agent (human or LLM) can understand them without external docs.\n\n  If using a type, add a type_def relation so the schema is validated:\n    "relations": { "type_def": [{ "ref": "<pubkey>.<type-uuid>" }] }\n\n  Structural objects should include a root relation for discoverability:\n    "relations": { "root": [{ "ref": "AxyU5_...00000000-...",\n      "url": "https://dataverse001.net/AxyU5_...00000000-..." }] }\n\nExample:\n  {\n    "type": "POST",\n    "name": "Hello",\n    "instruction": "A post. Display title and body.",\n    "content": { "title": "Hello!", "body": "First post!" }\n  }\n\nFlags:\n  --update      Allow updating existing objects (auto-increments revision,\n                sets updated_at). Without this, fails if object exists.\n  --identity N  Sign with identity N instead of active identity\n  --realm R     Override default realm (e.g. dataverse001, identity)\n  --push        Push to server (auto-login if needed for identity realm)\n  --no-push     Store locally only, skip server push\n\nFor a merge-not-replace update, field-level patches, relation edits, dry-run\nvalidation, or a conflict-safe checkout, see the write verbs:\n  ig new / ig edit / ig commit / ig validate / ig set / ig relate / ig unrelate`,
+
+    new: `Usage: ig new <type-ref> [--identity N] [--realm R] [--out FILE]\n\nScaffold a draft spec from a TYPE definition. No graph mutation.\n\nFetches the TYPE, reads its content.schema, and writes a draft with every\nrequired property stubbed (typed placeholders), type_def + root relations, and\na _draft metadata block. Edit the draft, then 'ig commit' it.\n\nFlags:\n  --identity N  Recorded in _draft (used later by ig commit)\n  --realm R     Recorded in _draft (used later by ig commit)\n  --out FILE    Output path (default: ./drafts/<type>-<timestamp>.json)\n\nOutput: the draft file path (stdout).`,
+    edit: `Usage: ig edit <ref> [--identity N] [--out FILE]\n\nCheck out the latest revision of your object for editing. No graph mutation.\n\nWrites the object's editable fields plus a _draft checkout block recording the\nbase revision, so 'ig commit' can detect a conflicting concurrent update.\nRefuses objects you do not own.\n\nFlags:\n  --identity N  Authenticate as identity N to read a private object\n  --out FILE    Output path (default: ./drafts/<ref>.json)\n\nOutput: the draft file path (stdout).`,
+    commit: `Usage: ig commit <draft.json> [--update <ref>] [--identity N] [--realm R] [--push|--no-push] [--dry-run]\n\nThe single door into the graph for drafts: parse -> resolve identity/realm ->\nenvelope checks -> route by mode -> schema validation -> relation checks ->\nsign -> store -> push.\n\nModes:\n  new         (default, or _draft.mode=new) create a new object\n  checkout    (_draft.mode=checkout) full-document update, with conflict check\n  --update R  deep-MERGE the draft onto R (omitted fields preserved)\n\nFlags:\n  --update R    Merge this bare spec onto object R (fixes the wipe-omitted gotcha)\n  --identity N  Sign with identity N (overrides _draft)\n  --realm R     Target realm (overrides _draft)\n  --push        Require a successful hub push (else exit 4)\n  --no-push     Store locally only\n  --dry-run     Validate only — sign/store/push nothing (exit 0 if valid)\n\nExit codes: 0 ok - 1 validation/parse - 2 usage - 3 conflict - 4 push failed.\nOn success prints: committed <ref> rev <N> (pushed | local-only).`,
+    validate: `Usage: ig validate <draft.json> [--update <ref>] [--identity N] [--realm R]\n\nAlias for 'ig commit --dry-run': run every check, then stop before signing.\nPrints 'valid: would create|update ...' and exits 0, or lists errors (exit 1).`,
+    set: `Usage: ig set <ref> <path> [<value>] [--json] [--delete] [--identity N]\n\nPatch a single field on your object, then re-sign and publish (revision +1).\n\n  <path>   dot-notation, e.g. content.title, content.tags, name, instruction\n  <value>  a string by default; with --json, parsed as JSON\n\nFlags:\n  --json        Parse <value> as JSON (numbers, booleans, arrays, objects, null)\n  --delete      Remove the key at <path> (no value argument)\n  --identity N  Authenticate as identity N\n\nRefuses signature-managed paths and whole-relations edits (use ig relate).\nOn success prints: committed <ref> rev <N> (pushed | local-only).`,
+    relate: `Usage: ig relate <ref> <relname> <target-ref> [--instruction TEXT] [--url URL]\n\nAdd a relation to your object (a new signed revision). Deduped by target ref:\nif already related, pass --instruction/--url to update it, else it errors.\nThe 'author' relation is managed automatically and cannot be set.\n\nOn success prints: committed <ref> rev <N> (pushed | local-only).`,
+    unrelate: `Usage: ig unrelate <ref> <relname> <target-ref>\n\nRemove a relation from your object (a new signed revision). Errors if the\nrelation entry is not present. An emptied relation key is removed entirely.`,
 
     identity: `Usage: ig identity [generate|activate|list] [options]\n\nShow or manage the active identity.\n\nFlags:\n  --identity N  Show info for identity N instead of the active one\n\nSubcommands:\n  ig identity generate [--name N] [--project] [--activate]\n  ig identity activate <name>\n  ig identity list\n\nEnvironment:\n  INSTRUCTIONGRAPH_DIR  Override config directory location`,
-    server: `Usage: ig server [set <url> | login | logout | remove | push]\n\nShow, configure, or remove the hub server connection.\n\nSubcommands:\n  ig server              Show current server status and auth\n  ig server set <url>    Connect to a hub server for sync\n  ig server login        Log in with your active identity\n  ig server logout       Log out from the hub\n  ig server remove       Disconnect and go offline\n  ig server push [--all]  Push local objects (default: your realms only)\n\nWithout a server, all data stays on local filesystem only.\nWith a server, objects sync between local storage and the hub.\nLogin uses your active identity (see ig identity).`,
+    server: `Usage: ig server [set <url> | login | logout | remove | push]\n\nShow, configure, or remove the hub server connection.\n\nSubcommands:\n  ig server              Show current server status and auth\n  ig server set <url>    Connect to a hub server for sync\n  ig server login        Log in with your active identity\n  ig server logout       Log out from the hub\n  ig server remove       Disconnect and go offline\n  ig server push [--all]  Push local objects (default: your realms only)\n  ig server push --ref R  Push exactly one object by ref\n\nWithout a server, all data stays on local filesystem only.\nWith a server, objects sync between local storage and the hub.\nLogin uses your active identity (see ig identity).`,
     realm: `Usage: ig realm [set <realm|identity|dataverse001|server-public|local>]\n\nShow or set the default realm used for new objects.\n\n  ig realm set identity       Use current identity\'s realm (private)\n  ig realm set dataverse001   Use the public dataverse realm\n  ig realm set server-public  Public on this hub, not propagated globally\n  ig realm set local          Local only \u2014 never synced to any server\n  ig realm set <pubkey>       Use any specific realm`
   }
 
@@ -788,7 +809,32 @@ function setServer() {
   console.log('  ig server push')
 }
 
+/** Push exactly one local object to the hub (the retry surface for commit exit 4). */
+async function serverPushOne(ref) {
+  const configDir = findConfigDir()
+  const hubUrl = readConfig(configDir, 'hub-url', null)
+  if (!hubUrl) die('No server configured. Run \'ig server set <url>\' first.')
+
+  const dataDir = join(configDir, 'data')
+  const local = createFsStore({ dataDir })
+  const obj = await local.get(ref, { skipRealmCheck: true }).catch(() => null)
+  if (!obj?.item) die(`Object not found locally: ${ref}`)
+
+  const hub = createHubStore({ url: hubUrl })
+  const savedToken = readConfig(configDir, 'auth-token', null)
+  if (savedToken) hub.setToken(savedToken)
+
+  let res
+  try { res = await hub.put(obj) }
+  catch (e) { die(`Push failed for ${ref}: ${e.message}`) }
+  if (res && res.ok === false) die(`Push failed for ${ref}: ${res.error || `status ${res.status}`}`)
+  console.log(`Pushed ${ref}.`)
+}
+
 async function serverPush() {
+  const singleRef = flag('ref')
+  if (singleRef) return serverPushOne(singleRef)
+
   const pushAll = args.includes('--all')
   const configDir = findConfigDir()
   const hubUrl = readConfig(configDir, 'hub-url', null)
@@ -912,6 +958,399 @@ async function serverLogout() {
 
   unlinkSync(tokenPath)
   console.log('Logged out.')
+}
+
+// ─── Write verbs (new / edit / commit / validate / set / relate / unrelate) ──
+//
+// Thin CLI wiring over library primitives (client.build/buildUpdate/validateType/
+// sign/publish). Diagnostics go to stderr prefixed `error:` (one per line);
+// stdout carries only machine-usable results. Exit codes: 0 ok · 1 validation/
+// parse/semantic · 2 usage · 3 revision conflict · 4 stored-but-push-failed.
+
+/** Emit `error:`-prefixed diagnostics to stderr, one line each. */
+function writeErr(msg) {
+  for (const line of Array.isArray(msg) ? msg : [msg]) process.stderr.write(`error: ${line}\n`)
+}
+/** Emit a non-error notice to stderr (used for fallbacks / advisories). */
+function writeNote(msg) { process.stderr.write(`note: ${msg}\n`) }
+/** Print diagnostics and exit with the given code. Never returns. */
+function failWrite(msg, code = 1) { writeErr(msg); process.exit(code) }
+
+/** Run a write-verb handler, mapping any unexpected throw to an `error:` line. */
+async function runWrite(fn) {
+  try { await fn() }
+  catch (e) { writeErr(e.message); process.exit(e.exitCode ?? 1) }
+}
+
+function draftTimestamp() {
+  const d = new Date()
+  const p = n => String(n).padStart(2, '0')
+  return `${d.getFullYear()}${p(d.getMonth() + 1)}${p(d.getDate())}-${p(d.getHours())}${p(d.getMinutes())}${p(d.getSeconds())}`
+}
+
+/** First unused path: `foo.json` → `foo-2.json` → `foo-3.json` … (never overwrites). */
+function uniquePath(p) {
+  if (!existsSync(p)) return p
+  const dot = p.lastIndexOf('.')
+  const base = dot === -1 ? p : p.slice(0, dot)
+  const ext = dot === -1 ? '' : p.slice(dot)
+  let i = 2
+  while (existsSync(`${base}-${i}${ext}`)) i++
+  return `${base}-${i}${ext}`
+}
+
+/** Choose a draft output path: --out FILE (as given), else ./drafts/<defaultName>. */
+function allocDraftPath(outFlag, defaultName) {
+  if (outFlag) return uniquePath(resolve(outFlag))
+  mkdirSync('drafts', { recursive: true })
+  return uniquePath(join('drafts', defaultName))
+}
+
+/** Look up a locally-known identity name owning `pubkey`, for friendlier errors. */
+async function localIdentityNameForPubkey(configDir, pubkey) {
+  const { importPEM } = await import('../src/identity.js')
+  for (const name of listIdentityNames(configDir)) {
+    const pem = resolveIdentityPemPath(configDir, name)
+    if (!pem) continue
+    try {
+      const kp = await importPEM(readFileSync(pem, 'utf-8'))
+      if (kp.pubkey === pubkey) return name
+    } catch { /* skip unreadable */ }
+  }
+  return null
+}
+
+/** Validate an item against its TYPE schema; on failure list every error, one per line. */
+async function validateOrFail(ctx, item) {
+  try {
+    await ctx.client.validateType(item)
+  } catch (e) {
+    const body = e.message.replace(/^TYPE validation failed: /, '')
+    failWrite(body.split('; '), 1)
+  }
+}
+
+/**
+ * Authenticate before an explicit push when the target realm is an identity realm
+ * and we hold no token yet (mirrors `ig create --push`).
+ */
+async function ensureAuthForPush(ctx, realms) {
+  if (!ctx.isOnline) return
+  const list = realms || []
+  const hasIdentityRealm = list.some(r =>
+    r !== 'dataverse001' && r !== 'local' && r !== 'server-public' && r.length === 44)
+  if (!hasIdentityRealm) return
+  if (readConfig(ctx.configDir, 'auth-token', null)) return
+  writeNote('authenticating to push to identity realm…')
+  const result = await ctx.client.authenticate()
+  if (!result.ok) failWrite('authentication failed — cannot push to identity realm.', 4)
+  writeConfig(ctx.configDir, 'auth-token', result.token)
+}
+
+/**
+ * Sign, store, and (unless noPush) push a finished item. Returns { ref, revision,
+ * pushed }. With requirePush, a failed hub push is exit 4 (object is stored locally).
+ */
+async function publishItem(ctx, item, { requirePush = false, noPush = false } = {}) {
+  const signed = await ctx.client.sign(item)
+  const revision = item.revision || 0
+
+  if (noPush) {
+    const local = createFsStore({ dataDir: join(ctx.configDir, 'data') })
+    const res = await local.put(signed)
+    if (!res.ok) failWrite(`could not store object locally: ${res.error}`, 1)
+    return { ref: item.ref, revision, pushed: false }
+  }
+
+  const res = await ctx.client.publish(signed)
+  if (!res.ok) failWrite(`could not store object: ${res.error || `status ${res.status}`}`, 1)
+  // Sync store reports the true push outcome via _remoteOk. A hub-only store
+  // (no local data dir) has no _remoteOk — a successful put there IS the push.
+  // An offline fs store is never pushed.
+  const isSync = typeof ctx.store.setRealmContext === 'function'
+  const pushed = isSync ? res._remoteOk === true : (ctx.isOnline && res.ok === true)
+  if (requirePush && !pushed) {
+    failWrite([
+      `stored ${item.ref} rev ${revision} locally, but the hub push failed: ${res._remoteError || 'unknown error'}`,
+      `retry the push with: ig server push --ref ${item.ref}`
+    ], 4)
+  }
+  return { ref: item.ref, revision, pushed }
+}
+
+/** Print the one-line success result and consume the draft if it lived under drafts/. */
+function reportCommitted(res, draftFile) {
+  console.log(`committed ${res.ref} rev ${res.revision} (${res.pushed ? 'pushed' : 'local-only'})`)
+  if (draftFile) {
+    const p = resolve(draftFile)
+    if (basename(dirname(p)) === 'drafts' && existsSync(p)) {
+      try { unlinkSync(p) } catch { /* leave it if we can't remove it */ }
+    }
+  }
+}
+
+// ─── ig new ──────────────────────────────────────────────────────
+
+async function cmdNew() {
+  const valueFlags = ['identity', 'realm', 'out']
+  validateFlags('new', args.slice(1), { valueFlags })
+  const [typeRef] = positionals(args.slice(1), valueFlags)
+  if (!typeRef) failWrite('usage: ig new <type-ref> [--identity N] [--realm R] [--out FILE]', 2)
+
+  const identityName = flag('identity')
+  const realm = flag('realm')
+  const ctx = await makeClient({ identityName, authenticate: !!identityName })
+  const typeObj = await ctx.client.get(typeRef).catch(() => null)
+  if (!typeObj?.item) {
+    failWrite([`TYPE not found: ${typeRef}`, `check the ref, or run 'ig get ${typeRef}' to confirm it exists.`], 1)
+  }
+  if (!typeObj.item.content?.schema) {
+    writeNote(`TYPE ${typeRef} has no schema — scaffolding a minimal draft; fill in content by hand.`)
+  }
+
+  const draft = buildDraft({ typeObj, typeRef, identityName, realm })
+  const typeName = typeObj.item.content?.name || 'draft'
+  const path = allocDraftPath(flag('out'), `${typeName}-${draftTimestamp()}.json`)
+  writeFileSync(path, JSON.stringify(draft, null, 2) + '\n')
+  console.log(path)
+}
+
+// ─── ig edit ─────────────────────────────────────────────────────
+
+async function cmdEdit() {
+  const valueFlags = ['identity', 'out']
+  validateFlags('edit', args.slice(1), { valueFlags })
+  const [ref] = positionals(args.slice(1), valueFlags)
+  if (!ref) failWrite('usage: ig edit <ref> [--identity N] [--out FILE]', 2)
+
+  const identityName = flag('identity')
+  const ctx = await makeClient({ identityName, authenticate: !!identityName })
+  if (!ctx.client.pubkey) failWrite("no identity configured. run 'ig identity generate' first.", 2)
+
+  const obj = await ctx.client.get(ref).catch(() => null)
+  if (!obj?.item) failWrite([`not found: ${ref}`, `check the ref, or run 'ig get ${ref}'.`], 1)
+  if (obj.item.pubkey !== ctx.client.pubkey) {
+    const owner = await localIdentityNameForPubkey(ctx.configDir, obj.item.pubkey)
+    failWrite([
+      'can only edit your own objects.',
+      `${ref} is owned by ${owner ? `identity '${owner}'` : `pubkey ${obj.item.pubkey}`}, not you (${ctx.client.pubkey}).`
+    ], 1)
+  }
+
+  // Editable payload = the item minus signature-managed fields.
+  const { pubkey, ref: _ref, signature, ...payload } = obj.item
+  const draft = {
+    ...payload,
+    _draft: {
+      mode: 'checkout',
+      base_ref: ref,
+      base_revision: obj.item.revision || 0,
+      ...(identityName ? { identity: identityName } : {})
+    }
+  }
+  const path = allocDraftPath(flag('out'), `${ref}.json`)
+  writeFileSync(path, JSON.stringify(draft, null, 2) + '\n')
+  console.log(path)
+}
+
+// ─── ig commit / ig validate ─────────────────────────────────────
+
+async function cmdCommit({ forceDryRun = false } = {}) {
+  const name = forceDryRun ? 'validate' : 'commit'
+  const booleanFlags = forceDryRun ? [] : ['push', 'no-push', 'dry-run']
+  const valueFlags = ['identity', 'realm', 'update']
+  validateFlags(name, args.slice(1), { booleanFlags, valueFlags })
+
+  const [file] = positionals(args.slice(1), valueFlags)
+  if (!file) failWrite(`usage: ig ${name} <draft.json> [--update <ref>] [--identity N] [--realm R]${forceDryRun ? '' : ' [--push|--no-push] [--dry-run]'}`, 2)
+
+  const dryRun = forceDryRun || args.includes('--dry-run')
+  const noPush = args.includes('--no-push')
+  const forcePush = args.includes('--push')
+  if (forcePush && noPush) failWrite('cannot use both --push and --no-push', 2)
+
+  // 1. Parse
+  let text
+  try { text = readFileSync(resolve(file), 'utf-8') }
+  catch { return failWrite(`cannot read draft file: ${file}`, 2) }
+  let parsed
+  try { parsed = parseDraftJSON(text) }
+  catch (e) { return failWrite(e.message, 1) }
+
+  // 2. Extract _draft (stripped from the payload — never signed)
+  const { draft, payload } = extractDraft(parsed)
+
+  // 4. Envelope checks (unknown / signature-managed top-level fields)
+  const envErrors = envelopeErrors(payload)
+  if (envErrors.length) failWrite(envErrors, 1)
+
+  // 3. Resolve identity / realm (flag > _draft > fallback), surfacing fallbacks
+  const configDir = findConfigDir()
+  const activeIdentity = readConfig(configDir, 'active-identity', 'default')
+  const defaultRealm = readConfig(configDir, 'default-realm', null)
+  const target = resolveCommitTarget({
+    draft, flagIdentity: flag('identity'), flagRealm: flag('realm'), activeIdentity, defaultRealm
+  })
+  if (target.identitySource === 'fallback') writeNote(`using active identity: ${target.identity}`)
+  const realm = await resolveRealmAlias(target.realm, configDir, target.identity)
+  if (target.realmSource === 'fallback') writeNote(`using default realm: ${realm ?? '(identity realm — private)'}`)
+
+  const identityName = target.identitySource === 'fallback' ? undefined : target.identity
+  const ctx = await makeClient({ identityName, realm })
+  if (!ctx.client.signer) failWrite("no identity configured. run 'ig identity generate' first.", 2)
+  if (forcePush && !ctx.isOnline) failWrite("cannot push — no server configured. run 'ig server set <url>' first.", 2)
+
+  // Explicit --realm overrides the object's realm regardless of mode.
+  if (target.realmSource === 'flag' && realm) payload.in = [realm]
+
+  // 5. Route by mode
+  const updateRef = flag('update')
+  const mode = updateRef ? 'merge' : (draft?.mode === 'checkout' ? 'checkout' : 'new')
+
+  let item, wouldMsg
+  if (mode === 'new') {
+    item = ctx.client.build(payload)
+    const existing = await ctx.store.get(item.ref, { skipRealmCheck: true }).catch(() => null)
+    if (existing?.item) {
+      failWrite([`object ${item.ref} already exists (rev ${existing.item.revision || 0}).`,
+        `to change it, run: ig edit ${item.ref}`], 1)
+    }
+    wouldMsg = payload.id ? `would create ${item.ref}` : `would create a new ${payload.type || 'object'} object`
+  } else if (mode === 'checkout') {
+    const baseRef = draft.base_ref
+    if (!baseRef) failWrite('checkout draft is missing _draft.base_ref — re-run: ig edit <ref>', 1)
+    const baseRevision = draft.base_revision || 0
+    let built
+    try {
+      built = await ctx.client.buildUpdate(baseRef, (orig) => {
+        const next = { id: orig.id, pubkey: orig.pubkey, ref: orig.ref, created_at: orig.created_at }
+        for (const k of ['type', 'name', 'instruction', 'content', 'relations', 'in', 'rights']) {
+          if (payload[k] !== undefined) next[k] = payload[k]
+        }
+        return next
+      })
+    } catch (e) { return failWrite(e.message, 1) }
+    if ((built.orig.revision || 0) !== baseRevision) {
+      failWrite([
+        `conflict: ${baseRef} is now at revision ${built.orig.revision || 0}, but your draft is based on ${baseRevision}.`,
+        `someone updated it since you checked it out. re-run: ig edit ${baseRef}`
+      ], 3)
+    }
+    item = built.item
+    wouldMsg = `would update ${baseRef} (rev ${baseRevision} → ${item.revision})`
+  } else { // merge
+    let built
+    try { built = await ctx.client.buildUpdate(updateRef, payload) }
+    catch (e) { return failWrite(e.message, 1) }
+    item = built.item
+    wouldMsg = `would update ${updateRef}`
+  }
+
+  // 6. Schema validation · 7. Relation shape checks
+  await validateOrFail(ctx, item)
+  const relErrors = relationRefErrors(item)
+  if (relErrors.length) failWrite(relErrors, 1)
+
+  // 8. Dry-run stops here — nothing signed, stored, or pushed
+  if (dryRun) { console.log(`valid: ${wouldMsg}`); return }
+
+  // 9. Sign → store → push · 10. Report
+  if (forcePush) await ensureAuthForPush(ctx, item.in)
+  const res = await publishItem(ctx, item, { requirePush: forcePush, noPush })
+  reportCommitted(res, file)
+}
+
+// ─── ig set ──────────────────────────────────────────────────────
+
+async function cmdSet() {
+  const valueFlags = ['identity']
+  validateFlags('set', args.slice(1), { booleanFlags: ['json', 'delete'], valueFlags })
+  const [ref, path, rawValue] = positionals(args.slice(1), valueFlags)
+  if (!ref || !path) failWrite('usage: ig set <ref> <path> [<value>] [--json] [--delete] [--identity N]', 2)
+
+  const isDelete = args.includes('--delete')
+  const isJson = args.includes('--json')
+  if (isDelete && rawValue !== undefined) failWrite('do not pass a value together with --delete', 2)
+  if (!isDelete && rawValue === undefined) failWrite(`provide a value, or pass --delete to remove '${path}'`, 2)
+
+  let value
+  if (!isDelete) {
+    if (isJson) {
+      try { value = JSON.parse(rawValue) } catch (e) { failWrite(`--json value is not valid JSON: ${e.message}`, 1) }
+    } else {
+      value = rawValue
+    }
+  }
+
+  const identityName = flag('identity')
+  const ctx = await makeClient({ identityName, authenticate: !!identityName })
+  if (!ctx.client.signer) failWrite("no identity configured. run 'ig identity generate' first.", 2)
+
+  let built
+  try {
+    built = await ctx.client.buildUpdate(ref, (item) => {
+      if (isDelete) deleteAtPath(item, path); else setAtPath(item, path, value)
+      return item
+    })
+  } catch (e) { return failWrite(e.message, 1) }
+
+  await validateOrFail(ctx, built.item)
+  const relErrors = relationRefErrors(built.item)
+  if (relErrors.length) failWrite(relErrors, 1)
+  const res = await publishItem(ctx, built.item, {})
+  reportCommitted(res)
+}
+
+// ─── ig relate / ig unrelate ─────────────────────────────────────
+
+async function cmdRelate() {
+  const valueFlags = ['instruction', 'url', 'identity']
+  validateFlags('relate', args.slice(1), { valueFlags })
+  const [ref, relname, target] = positionals(args.slice(1), valueFlags)
+  if (!ref || !relname || !target) {
+    failWrite('usage: ig relate <ref> <relname> <target-ref> [--instruction TEXT] [--url URL]', 2)
+  }
+  const instruction = flag('instruction')
+  const url = flag('url')
+  const identityName = flag('identity')
+  const ctx = await makeClient({ identityName, authenticate: !!identityName })
+  if (!ctx.client.signer) failWrite("no identity configured. run 'ig identity generate' first.", 2)
+
+  let built
+  try {
+    built = await ctx.client.buildUpdate(ref, (item) => {
+      addRelation(item, relname, target, { instruction, url })
+      return item
+    })
+  } catch (e) { return failWrite(e.message, 1) }
+
+  await validateOrFail(ctx, built.item)
+  const res = await publishItem(ctx, built.item, {})
+  reportCommitted(res)
+}
+
+async function cmdUnrelate() {
+  const valueFlags = ['identity']
+  validateFlags('unrelate', args.slice(1), { valueFlags })
+  const [ref, relname, target] = positionals(args.slice(1), valueFlags)
+  if (!ref || !relname || !target) {
+    failWrite('usage: ig unrelate <ref> <relname> <target-ref>', 2)
+  }
+  const identityName = flag('identity')
+  const ctx = await makeClient({ identityName, authenticate: !!identityName })
+  if (!ctx.client.signer) failWrite("no identity configured. run 'ig identity generate' first.", 2)
+
+  let built
+  try {
+    built = await ctx.client.buildUpdate(ref, (item) => {
+      removeRelation(item, relname, target)
+      return item
+    })
+  } catch (e) { return failWrite(e.message, 1) }
+
+  await validateOrFail(ctx, built.item)
+  const res = await publishItem(ctx, built.item, {})
+  reportCommitted(res)
 }
 
 // ─── Status ──────────────────────────────────────────────────────
@@ -1184,6 +1623,34 @@ async function main() {
       break
     }
 
+    case 'new':
+      await runWrite(cmdNew)
+      break
+
+    case 'edit':
+      await runWrite(cmdEdit)
+      break
+
+    case 'commit':
+      await runWrite(() => cmdCommit({ forceDryRun: false }))
+      break
+
+    case 'validate':
+      await runWrite(() => cmdCommit({ forceDryRun: true }))
+      break
+
+    case 'set':
+      await runWrite(cmdSet)
+      break
+
+    case 'relate':
+      await runWrite(cmdRelate)
+      break
+
+    case 'unrelate':
+      await runWrite(cmdUnrelate)
+      break
+
     case 'auth':  // hidden alias for 'ig server login'
       validateFlags('server login', args.slice(1))
       await serverLogin()
@@ -1247,7 +1714,7 @@ async function main() {
         validateFlags('server remove', args.slice(2))
         removeServer()
       } else if (subcmd === 'push') {
-        validateFlags('server push', args.slice(2), { booleanFlags: ['all'] })
+        validateFlags('server push', args.slice(2), { booleanFlags: ['all'], valueFlags: ['ref'] })
         await serverPush()
       } else {
         die('Usage: ig server [set <url> | login | logout | remove | push]')

--- a/specs/20260707-ig-write-verbs-deviations.md
+++ b/specs/20260707-ig-write-verbs-deviations.md
@@ -113,9 +113,57 @@ Fallback/advisory lines (`using active identity: …`, `TYPE … has no schema �
 `authenticating to push …`) are printed to stderr prefixed `note:`, distinct
 from `error:`. stdout still carries only the machine-usable result.
 
-## Known limitation
+## Hardening from code review
 
-`ig set <ref> <path> <value>` where `<value>` begins with `-` is not supported —
-the positional parser treats a leading-dash token as a flag. Rare for the target
-fields (titles, names, tags); use `ig edit` + `ig commit` for such values. Noted
-rather than fixed to keep the arg parser consistent with the rest of the CLI.
+A multi-agent review pass surfaced these; all are fixed and covered by tests in
+`test/write-verbs.test.js` (`describe('hardening')`):
+
+- **`ig new` filename injection.** The default draft filename derives from the
+  fetched TYPE's `content.name`, which is attacker-controllable. It is now
+  sanitized (`[^A-Za-z0-9._-]` → `_`, leading dots stripped) so a name like
+  `../../evil` cannot write outside `drafts/`.
+- **Draft-supplied `author` relation.** `author` is signature-managed, so
+  `ig commit` strips any `relations.author` from the draft: `new` rebuilds it
+  from the signer, `merge` preserves the original, `checkout` restores it from
+  the original in the patch. (Matches `ig relate`/`set`, which already refuse it.)
+- **Checkout dropping `in`.** A checkout draft that deletes `in` no longer
+  produces a realm-less (orphaned, owner-invisible, push-gate-bypassing) object:
+  the checkout patch falls back to the original `in`, and a final guard rejects
+  any item with an empty/missing realm.
+- **`ig commit <checkout-draft> --update`** is a contradiction (checkout =
+  full-replace, `--update` = merge) and is now refused with exit 2, rather than
+  silently switching to merge and dropping the conflict check.
+- **`drafts/` auto-delete** is scoped to the tool's own `./drafts` (resolved
+  against cwd), so committing a user file that merely happens to sit under some
+  other directory named `drafts` never deletes it.
+- **`ig set` multi-word values.** Extra positional tokens after the value (an
+  unquoted multi-word value) are now an exit-2 error telling the user to quote,
+  instead of being silently truncated to the first word.
+- **Write-verb error contract on shared helpers.** While a write verb runs,
+  `die()` (used by `validateFlags` and `makeClient`) emits `error:`-prefixed
+  stderr and exits 2, so bad flags / unknown `--identity` / unconfigured store
+  honour §4 like the rest of the verb. Other (non-write) commands are unchanged.
+- **`ensureAuthForPush` failure** is exit 1 (not the exit-4 "stored locally"
+  code), because nothing is signed or stored when pre-push auth fails.
+
+## Known limitations (deliberately out of scope)
+
+- **Leading-dash values.** `ig set <ref> <path> <value>` where `<value>` begins
+  with `-` is not supported — the positional parser treats a leading-dash token
+  as a flag. Rare for the target fields (titles, names, tags); use `ig edit` +
+  `ig commit` for such values. Left as-is to keep the arg parser consistent with
+  the rest of the CLI.
+- **`set`/`relate`/`unrelate` are last-write-wins.** They load the latest
+  revision, apply the change, and save; they carry no base revision, so two
+  concurrent edits can still clobber (the underlying `store.put` only rejects a
+  *lower* incoming revision, not an equal one — pre-existing store behaviour).
+  Spec §3.5/§3.6 don't ask these verbs for a conflict check; `ig edit` +
+  `ig commit` is the conflict-safe path (exit 3). Not changed here.
+- **Draft path allocation is check-then-act.** `allocDraftPath`/`uniquePath`
+  test with `existsSync` and don't reserve the slot, so two `ig new` invocations
+  in the same second could compute the same path. Acceptable for an interactive
+  CLI; noted rather than adding file-locking.
+- **Auto-auth duplication.** `ensureAuthForPush` overlaps with the inline
+  auto-auth block in the `ig create` handler. Left un-merged to avoid changing
+  the established, separately-tested `create` behaviour; the write verbs use the
+  new helper.

--- a/specs/20260707-ig-write-verbs-deviations.md
+++ b/specs/20260707-ig-write-verbs-deviations.md
@@ -1,0 +1,121 @@
+# Deviations & decisions — ig write verbs
+
+Implementation notes for `specs/20260707-ig-write-verbs.md`. Records the calls
+made on the spec's open questions (§7) and other judgement points, so a reviewer
+can see *why* the code does what it does.
+
+## Open questions (§7)
+
+### 1. Per-object push retry surface (3.3)
+
+No per-object push existed — only `ig server push [--all]` (bulk). Added
+**`ig server push --ref <ref>`**: loads that one object from the local store and
+PUTs it to the hub (using the saved auth token). This is exactly the retry
+command `ig commit --push` prints on exit 4:
+
+```
+error: stored <ref> rev N locally, but the hub push failed: <reason>
+error: retry the push with: ig server push --ref <ref>
+```
+
+`--all` is never suggested (per the spec's explicit instruction).
+
+### 2. `drafts/` in `.gitignore`
+
+**Not** added to `.gitignore`, and no scaffolding advice emitted. Rationale:
+`ig` is a library/CLI used from arbitrary working directories, not tied to one
+repo; `ig commit` already deletes a consumed draft that lives under `drafts/`,
+so drafts are transient by default. Injecting a `.gitignore` line would be a
+surprising side effect for a data CLI. Users who want to keep drafts out of
+version control can add the line themselves. (Left as a doc-only concern.)
+
+### 3. Placeholder text format for `ig new` stubs
+
+Optimised for a small model to recognise and replace. Rules (`src/scaffold.js`):
+
+| schema             | placeholder                         |
+|--------------------|-------------------------------------|
+| string             | `"<string: {description}>"`         |
+| optional string    | `"<optional string: {description}>"`|
+| integer / number   | `0`                                 |
+| boolean            | `false`                             |
+| enum               | `"<one of: a \| b \| c>"`           |
+| array of scalars   | `["<…item placeholder…>"]` (one example element) |
+| array of objects   | `[]`                                |
+| object w/ props    | recurse into its properties         |
+| object, no props   | `{}`                                |
+
+- `{description}` comes from the property's `description`, else `replace me`.
+- Optional-ness is only marked inside string/enum placeholders (a `0`/`false`
+  can't carry text). Required properties are emitted **before** optional ones,
+  in the order the schema's `required` array lists them.
+- `name`/`instruction` get `"<replace: …>"` placeholders (both are strings, so
+  they satisfy any item-level `required` on those fields as-is).
+
+## Other decisions
+
+### Item-level TYPE schemas
+
+`client.validateType` validates the **whole item** against `content.schema`
+(confirmed by `test/client.test.js` — item-level `required` like `instruction`
+are checked). So a TYPE's schema is item-level with the content shape under
+`properties.content`. `ig new` therefore scaffolds `content` from
+`contentSchemaOf(schema)` = `schema.properties.content`, falling back to treating
+the schema itself as the content schema for content-only TYPEs.
+
+### `commit` mode routing precedence
+
+1. `--update <ref>` present → **merge** (deep-merge onto ref), overrides `_draft`.
+2. else `_draft.mode === 'checkout'` → **checkout** (full-document replace + conflict check).
+3. else → **new** (create).
+
+`--update` wins because it is the most explicit signal the caller can give.
+
+### `client.buildUpdate` (library addition)
+
+Factored the fetch+merge+immutable+revision logic out of `client.update` into
+`client.buildUpdate(ref, patch) → { item, orig }` (no signing/publishing).
+`update()` now delegates to it (behaviour unchanged). This lets the CLI validate,
+inspect, dry-run, and report on the computed item — and read the real push
+outcome — while still reusing the library's deep-merge/immutable semantics
+(spec's "expose, don't reinvent" principle). `orig` is returned so `commit`'s
+checkout path can compare the stored revision for the conflict check.
+
+### `pushed | local-only` detection
+
+Read from the sync store's `_remoteOk` (the true hub outcome). A hub-only store
+(no local data dir) has no `_remoteOk`, so there a successful `put` counts as
+pushed; an offline fs store is always `local-only`.
+
+### `set --delete` / `unrelate` on absent targets → error, not no-op
+
+Both **error** when the target key/relation isn't present, surfacing the state
+mismatch rather than silently succeeding (consistent with the spec's stance on
+`relate`/`unrelate`, extended to `set --delete`).
+
+### `set` refuses all `relations.*` paths
+
+The spec refuses `relations.author` and "whole-relations edits". Implemented as:
+any path whose first segment is `relations` is refused and points at
+`ig relate` / `ig unrelate`. Field-level relation edits therefore always go
+through the dedicated verbs.
+
+### Realm on `checkout`
+
+An explicit `--realm` overrides the object's realm on any mode. A `_draft.realm`
+value is honoured for `new`, but on `checkout` the object keeps its existing
+`in` (the checked-out payload carries it) unless `--realm` is passed. Changing an
+object's realm on a routine content update is unusual; require the explicit flag.
+
+### Notices vs errors on stderr
+
+Fallback/advisory lines (`using active identity: …`, `TYPE … has no schema …`,
+`authenticating to push …`) are printed to stderr prefixed `note:`, distinct
+from `error:`. stdout still carries only the machine-usable result.
+
+## Known limitation
+
+`ig set <ref> <path> <value>` where `<value>` begins with `-` is not supported —
+the positional parser treats a leading-dash token as a flag. Rare for the target
+fields (titles, names, tags); use `ig edit` + `ig commit` for such values. Noted
+rather than fixed to keep the arg parser consistent with the rest of the CLI.

--- a/specs/20260707-ig-write-verbs.md
+++ b/specs/20260707-ig-write-verbs.md
@@ -1,0 +1,192 @@
+# SPEC: ig write verbs — an agent-ergonomic write path
+
+- **Date**: 2026-07-07
+- **Status**: approved for implementation
+- **Author**: Tijs Zwinkels + Claude (design conversation, 2026-07-07)
+- **Repo**: `instructiongraph-js`
+- **Origin**: "InstructionGraph as filesystem" design discussion. Conclusion there: reads get
+  friendlier projections later (directory/HTTP); **writes move to explicit CLI verbs with forced,
+  synchronous, message-carrying feedback**. This spec covers only the write verbs.
+
+## 1. Motivation
+
+LLM agents — especially small models — make avoidable mistakes writing dataverse objects:
+
+1. **Whole-document re-emission.** Today the only update path is `ig create --update` with a *full*
+   spec. Re-emitting a whole document to change one field is where errors happen, and the CLI's
+   update path **replaces** rather than merges: omitted top-level fields (e.g. `name`) are wiped.
+   (Known production gotcha.)
+2. **Envelope boilerplate.** Agents hand-type `type_def`/`root` relations, realm, and structure that
+   could be generated from the TYPE definition.
+3. **No dry-run.** There is no way to validate a spec without signing/publishing it.
+4. **No concurrency safety.** Two agents editing the same object silently last-write-win.
+
+## 2. Current state (verified 2026-07-07)
+
+- `ig create <spec.json> [--update] [--identity N] [--realm R] [--push|--no-push]` — builds from a
+  full spec. Update path (`cli/ig.js` ~1096–1180, `src/client.js` ~200–225) rebuilds the item from
+  the spec's fields: **replace semantics**, preserving only `id`/`created_at` and auto-bumping
+  `revision`/`updated_at`.
+- `client.update(ref, patch)` (`src/client.js` ~250–283) **already implements deep-merge** semantics
+  (`deepMerge`), preserves immutables (`id`, `ref`, `pubkey`, `created_at`), bumps revision, runs
+  schema validation. **It is not exposed by the CLI.** The patch-function form
+  (`update(ref, item => {...})`) also exists.
+- Schema validation exists: `client.validateType(item)` validates `item` against the `type_def`
+  TYPE's `content.schema` via `validateSchema` (`src/validation.js`; subset: `type`, `enum`,
+  `required`, `properties`, `items`). Skips silently when no `type_def`/schema.
+- Store (`src/store/fs.js`): canonical JSON + trailing newline, revision backups in
+  `data/bk/{ref}.r{rev}.json`, signature verified on put.
+- No scaffold command, no dry-run, no field-level patch, no relation add/remove, no revision-based
+  conflict detection.
+
+**Design principle:** the new verbs are thin CLI wiring over existing library primitives
+(`client.build/validateType/sign/publish/update`). Prefer exposing what exists over new machinery.
+
+## 3. New commands
+
+### 3.1 `ig new <type-ref> [--identity N] [--realm R] [--out FILE]`
+
+Scaffold a draft spec from a TYPE definition. No graph mutation.
+
+- Fetch the TYPE object (store, then hub). Error if not found or if it has no `content.schema`
+  (still scaffold a minimal draft in that case, with a notice).
+- Emit a draft JSON file containing:
+  - `type` — the TYPE's `content.name`
+  - `name`, `instruction` — placeholder strings the author must replace
+  - `content` — stubs generated from the schema: every `required` property present; property values
+    are placeholders derived from the schema type (`"<string: {description}>"`, `0`, `false`, `[]`,
+    `{}`); optional properties included but clearly marked in the placeholder text
+  - `relations` — `type_def` → the TYPE ref, `root` → the genesis object (same shape `ig create`'s
+    help documents today)
+  - `_draft` — metadata block: `{ "mode": "new", "type_ref": ..., "identity": ..., "realm": ... }`
+    (identity/realm from flags; omitted keys stay absent — see 3.3 resolution rules)
+- Default output: `./drafts/<type-name>-<yyyymmdd-HHMMSS>.json` (create `drafts/` if needed). Never
+  overwrite an existing file — append a suffix. Print the path as the only stdout line.
+
+### 3.2 `ig edit <ref> [--identity N] [--out FILE]`
+
+Check out the latest revision of an existing object for editing. No graph mutation.
+
+- Fetch latest (store first, hub fallback). Error if not found.
+- Error if `item.pubkey` ≠ the signing identity's pubkey ("can only edit your own objects";
+  name the owning identity if it's a locally-known one).
+- Write the full item payload (without signature envelope) to a draft file, plus
+  `_draft: { "mode": "checkout", "base_ref": <ref>, "base_revision": <revision>, "identity": ... }`.
+- Default output: `./drafts/<ref>.json`; same no-overwrite rule. Print the path.
+
+### 3.3 `ig commit <draft.json> [--update <ref>] [--identity N] [--realm R] [--push|--no-push] [--dry-run]`
+
+The single door into the graph for drafts. Pipeline, failing fast with a specific message per stage:
+
+1. **Parse** — JSON syntax errors reported with line/column.
+2. **Extract `_draft`** — strip it from the payload; it never gets signed.
+3. **Resolve identity/realm** — precedence: CLI flag > `_draft` value. If neither is present for
+   identity, fall back to the active identity but **print which identity is being used**; `--realm`
+   falls back to the configured default realm the same way. (Keeps parity with `ig create` while
+   making the resolution visible.)
+4. **Envelope checks** — reject unknown top-level fields (typo protection; list allowed fields in
+   the error). Reject specs that set signature-managed fields (`pubkey`, `ref`, `signature`).
+5. **Route by mode**:
+   - `mode: "new"` (or no `_draft` and no `--update`): create path. If an object with this `id`
+     already exists → error pointing at `ig edit`.
+   - `mode: "checkout"`: full-document update of `base_ref`. **Conflict check**: if the stored
+     revision ≠ `base_revision`, fail (exit 3) with both revisions and the hint to re-run
+     `ig edit`. Immutables (`id`, `ref`, `pubkey`, `created_at`) preserved from the original
+     regardless of draft contents; `revision = base_revision + 1`.
+   - bare spec + `--update <ref>`: **merge** path via `client.update(ref, patch)` — deep-merge onto
+     the latest stored revision. Omitted fields are *preserved* (this is the fix for the
+     wipes-omitted-fields gotcha). No conflict check (no base revision to compare).
+6. **Schema validation** — `validateType`; report **all** errors, one per line, with JSON paths.
+7. **Relation checks** — every ref in `relations` must match the `<pubkey>.<uuid>` shape; malformed
+   refs are errors. (Unresolvable-but-well-formed refs are allowed — the graph is open.)
+8. **`--dry-run` stops here** — print `valid: <would create|update ref> …` and exit 0. Nothing is
+   signed, stored, or pushed.
+9. **Sign → store → push** — existing create/update/publish machinery, including `bk/` backups.
+   Push behavior and flags identical to `ig create` today.
+10. **Report** — success prints exactly one stdout line:
+    `committed <ref> rev <N> (pushed | local-only)`. On success, delete the draft file if it lives
+    under `drafts/` (it's consumed); otherwise leave it.
+
+**Push failure** is not a validation failure: the object is signed and stored locally. Exit 4 with a
+message stating that, plus the exact retry command (implementer: verify what per-object push exists —
+if only `ig server push` bulk exists, add a `--ref <ref>` filter to it as part of this work; never
+suggest `--all`).
+
+### 3.4 `ig validate <draft.json> [--update <ref>]`
+
+Alias for `ig commit --dry-run`. Exists because "validate" is what agents will reach for.
+
+### 3.5 `ig set <ref> <path> [<value>] [--json] [--delete] [--identity N]`
+
+Single-field patch — the workhorse verb. Load latest → apply one change → validate → sign → store →
+push (same tail as commit).
+
+- `<path>` is dot-notation into the item: `content.title`, `content.tags`, `name`, `instruction`.
+- Refuse envelope/signature-managed paths (`id`, `ref`, `pubkey`, `revision`, `created_at`,
+  `updated_at`, `signature`, `relations.author`) and whole-`relations` edits (point at
+  `ig relate`/`ig unrelate`).
+- `<value>` is a string by default; `--json` parses it as JSON (numbers, booleans, arrays, objects,
+  null); `--delete` removes the key (no value argument).
+- Implement via `client.update(ref, item => …)` (patch-function form) so merge/immutable/revision
+  semantics come from the library.
+- Success output: `committed <ref> rev <N> (pushed | local-only)`.
+
+### 3.6 `ig relate <ref> <relname> <target-ref> [--instruction TEXT] [--url URL]` / `ig unrelate <ref> <relname> <target-ref>`
+
+Relation add/remove as first-class operations (a relation edit = new signed revision of the source).
+
+- `relate`: append `{ ref: target, ...(instruction), ...(url) }` to `relations.<relname>`, creating
+  the array if needed. **Dedupe by target ref**: if the target is already present, update its
+  `instruction`/`url` when flags are given, otherwise error "already related" (exit 1) — silent
+  success would hide agent confusion.
+- `unrelate`: remove the entry; if absent, error stating the relation didn't exist (defensive:
+  communicate the state mismatch, don't no-op). Remove the `relations.<relname>` key entirely when
+  the array empties.
+- `relname` `author` is refused (signature-managed).
+- Both validate the target ref shape; both go through the same validate/sign/store/push tail.
+
+## 4. Error contract (all verbs)
+
+- Exit codes: `0` success · `1` validation/parse/semantic error · `2` usage error · `3` revision
+  conflict · `4` stored-locally-but-push-failed.
+- All diagnostics to **stderr**, prefixed `error:` (one per line for multi-error validation);
+  stdout carries only machine-usable results (paths, `committed …` lines).
+- Every error message must say *what to do next* (the fix, the command to run, or the field to
+  change). These messages are the product — they are what the LLM reads. Write them for a small
+  model: concrete, one action, no jargon.
+
+## 5. Out of scope
+
+- `ig create` behavior is **unchanged** (backward compat). Its `--help` gains a pointer to the new
+  verbs.
+- Filesystem/HTTP projections of the graph, daemons, mounts — separate future work.
+- Hub/server changes (except the optional per-object push filter noted in 3.3).
+- New TYPE-authoring helpers.
+
+## 6. Testing requirements
+
+TDD throughout: write the failing test first, watch it fail, make it pass. `node --test`, following
+existing `test/*.test.js` + `test-support/` isolation patterns. **Never touch the developer's real
+store or a live hub** — temp-dir stores only.
+
+Minimum coverage, per verb:
+
+- `new`: scaffold contains all schema-required properties; placeholders typed per schema; `type_def`
+  + `root` relations present; no-overwrite naming; TYPE without schema → minimal draft + notice.
+- `edit`: checkout carries correct `base_revision`; foreign-owned object refused.
+- `commit`: happy create; happy checkout-update; **regression: merge path preserves omitted
+  top-level fields** (the `--update` gotcha, red first against `create --update` semantics);
+  conflict → exit 3; unknown top-level field → exit 1 naming it; multi-error validation lists all;
+  `--dry-run` leaves store untouched (assert no file, no `bk/` entry); push failure → object in
+  store + exit 4; `_draft` never appears in the signed item.
+- `set`: nested path set; `--json` types; `--delete`; refused paths; revision increments by exactly 1.
+- `relate`/`unrelate`: add creates array; dedupe error; instruction update on existing; unrelate
+  missing → error; empty array key removed; `author` refused.
+- Cross-cutting: exit codes as specified; stdout/stderr separation (assert stdout is exactly the
+  documented line).
+
+## 7. Open questions (implementer decides, records in a deviations note)
+
+1. Exact per-object push retry surface (3.3) if none exists.
+2. Whether `drafts/` should land in the repo's `.gitignore` scaffolding advice.
+3. Placeholder text format for `ig new` stubs — optimize for "a small model replaces it correctly".

--- a/src/client.js
+++ b/src/client.js
@@ -245,9 +245,19 @@ export function createClient(opts = {}) {
       return signed.item.ref
     },
 
-    // ─── Update (fetch + merge + sign + publish) ───
+    // ─── Build an update (fetch + merge, no signing) ───
 
-    async update(ref, patch) {
+    /**
+     * Compute an updated item from the latest stored revision, without signing
+     * or publishing. Deep-merges a partial patch (or applies a patch function),
+     * preserves immutables, and bumps revision — the same semantics as update(),
+     * exposed so callers can validate/inspect/report before committing.
+     *
+     * @param {string} ref
+     * @param {object|Function} patch - partial patch object, or item => item
+     * @returns {Promise<{ item: object, orig: object }>}
+     */
+    async buildUpdate(ref, patch) {
       requireIdentity()
       const current = await store.get(ref)
       if (!current?.item) throw new Error(`Object not found: ${ref}`)
@@ -273,8 +283,15 @@ export function createClient(opts = {}) {
       updated.updated_at = isoNow()
       updated.revision = (orig.revision || 0) + 1
 
-      await client.validateType(updated)
-      const signed = await client.sign(updated)
+      return { item: updated, orig }
+    },
+
+    // ─── Update (buildUpdate + validate + sign + publish) ───
+
+    async update(ref, patch) {
+      const { item } = await client.buildUpdate(ref, patch)
+      await client.validateType(item)
+      const signed = await client.sign(item)
       const result = await client.publish(signed)
       if (!result.ok) throw new Error(`Publish failed: ${result.error || `status ${result.status}`}`)
       return signed.item.ref

--- a/src/draft.js
+++ b/src/draft.js
@@ -1,0 +1,99 @@
+/**
+ * Draft parsing and envelope checks behind `ig commit` / `ig validate`.
+ *
+ * A draft is a plain spec object, optionally carrying a `_draft` metadata block
+ * (mode + provenance) that is stripped before signing and never persisted.
+ */
+
+// Top-level fields a draft may carry into the signed item. Mirrors what
+// buildItem accepts, minus the signature-managed fields below.
+export const ALLOWED_TOP_LEVEL = new Set([
+  'type', 'name', 'instruction', 'content', 'relations', 'in',
+  'id', 'created_at', 'updated_at', 'revision', 'rights'
+])
+
+// Fields the signer derives; a draft must not set them.
+const SIGNATURE_MANAGED = ['pubkey', 'ref', 'signature']
+
+/** Line/column (1-based) for a character offset into `text`. */
+function lineColFromPos(text, pos) {
+  let line = 1
+  let col = 1
+  for (let i = 0; i < pos && i < text.length; i++) {
+    if (text[i] === '\n') { line++; col = 1 } else { col++ }
+  }
+  return { line, col }
+}
+
+/**
+ * Parse draft JSON, reporting syntax errors with line/column.
+ * @param {string} text
+ * @returns {object}
+ */
+export function parseDraftJSON(text) {
+  try {
+    return JSON.parse(text)
+  } catch (e) {
+    const msg = e.message
+    if (/line \d+ column \d+/.test(msg)) throw new Error(`invalid JSON: ${msg}`)
+    const posMatch = /position (\d+)/.exec(msg)
+    if (posMatch) {
+      const { line, col } = lineColFromPos(text, Number(posMatch[1]))
+      throw new Error(`invalid JSON at line ${line} column ${col}: ${msg}`)
+    }
+    throw new Error(`invalid JSON: ${msg}`)
+  }
+}
+
+/**
+ * Split a parsed draft into its `_draft` metadata and the payload to sign.
+ * @param {object} parsed
+ * @returns {{ draft: object|null, payload: object }}
+ */
+export function extractDraft(parsed) {
+  const { _draft = null, ...payload } = parsed
+  return { draft: _draft, payload }
+}
+
+/**
+ * Collect envelope errors: unknown top-level fields (typo protection) and
+ * signature-managed fields that must not appear in a draft.
+ * @param {object} payload
+ * @returns {string[]}
+ */
+export function envelopeErrors(payload) {
+  const errors = []
+  for (const key of Object.keys(payload)) {
+    if (SIGNATURE_MANAGED.includes(key)) {
+      errors.push(`remove '${key}': it is set automatically when signing, not written in the draft`)
+    } else if (!ALLOWED_TOP_LEVEL.has(key)) {
+      errors.push(`unknown field '${key}'. allowed fields: ${[...ALLOWED_TOP_LEVEL].join(', ')}`)
+    }
+  }
+  return errors
+}
+
+/**
+ * Resolve which identity/realm a commit uses. Precedence: CLI flag > _draft >
+ * fallback (active identity / configured default realm). The source is returned
+ * so the caller can surface fallbacks visibly.
+ * @param {object} args
+ * @param {object|null} args.draft
+ * @param {string} [args.flagIdentity]
+ * @param {string} [args.flagRealm]
+ * @param {string} [args.activeIdentity]
+ * @param {string} [args.defaultRealm]
+ */
+export function resolveCommitTarget({ draft, flagIdentity, flagRealm, activeIdentity, defaultRealm }) {
+  const pick = (flag, fromDraft, fallback) => {
+    if (flag != null) return { value: flag, source: 'flag' }
+    if (fromDraft != null) return { value: fromDraft, source: 'draft' }
+    return { value: fallback, source: 'fallback' }
+  }
+  const id = pick(flagIdentity, draft?.identity, activeIdentity)
+  const rlm = pick(flagRealm, draft?.realm, defaultRealm)
+  return {
+    identity: id.value, identitySource: id.source,
+    realm: rlm.value, realmSource: rlm.source
+  }
+}

--- a/src/patch-ops.js
+++ b/src/patch-ops.js
@@ -1,0 +1,152 @@
+/**
+ * Pure item mutations behind `ig set` / `ig relate` / `ig unrelate`, plus the
+ * relation-shape checks `ig commit` runs. Each function mutates a plain item in
+ * place and throws an Error whose message tells the caller exactly what to fix —
+ * these messages are read by the LLM, so they name one concrete action.
+ */
+
+// A ref is <pubkey>.<uuid>: a base64url key, a dot, then a canonical UUID.
+const REF_RE = /^[A-Za-z0-9_-]{20,}\.[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/
+
+// Fields that signing manages; `ig set` must never touch them.
+const MANAGED_SET_SEGMENTS = new Set(['id', 'ref', 'pubkey', 'revision', 'created_at', 'updated_at', 'signature'])
+
+function isPlainObject(v) {
+  return v !== null && typeof v === 'object' && !Array.isArray(v)
+}
+
+/** @returns {boolean} whether `ref` has the <pubkey>.<uuid> shape. */
+export function isValidRef(ref) {
+  return typeof ref === 'string' && REF_RE.test(ref)
+}
+
+/** Throw if `ref` is not a well-formed <pubkey>.<uuid>. */
+export function assertValidRef(ref) {
+  if (!isValidRef(ref)) {
+    throw new Error(`malformed ref '${ref}': expected <pubkey>.<uuid> (a key, a dot, then a UUID)`)
+  }
+}
+
+/** Throw if `path` targets a field `ig set` may not change. */
+export function assertSettablePath(path) {
+  if (!path || typeof path !== 'string') throw new Error(`invalid path: '${path}'`)
+  const segs = path.split('.')
+  if (segs.some(s => s === '')) throw new Error(`invalid path '${path}': empty segment`)
+  if (segs[0] === 'relations') {
+    throw new Error(`use 'ig relate' / 'ig unrelate' to change relations, not 'ig set'`)
+  }
+  if (MANAGED_SET_SEGMENTS.has(segs[0])) {
+    throw new Error(`'${segs[0]}' is set automatically when signing and can't be changed with 'ig set'`)
+  }
+}
+
+/** Walk to the parent object of the leaf segment. Optionally create missing objects. */
+function navigate(item, path, { create }) {
+  const segs = path.split('.')
+  let node = item
+  for (let i = 0; i < segs.length - 1; i++) {
+    const s = segs[i]
+    if (node[s] === undefined) {
+      if (!create) return { parent: null, key: segs[segs.length - 1], segs }
+      node[s] = {}
+    }
+    if (!isPlainObject(node[s])) {
+      throw new Error(`can't set '${path}': '${segs.slice(0, i + 1).join('.')}' is not an object`)
+    }
+    node = node[s]
+  }
+  return { parent: node, key: segs[segs.length - 1], segs }
+}
+
+/** Set `item.<path> = value`, creating intermediate objects as needed. */
+export function setAtPath(item, path, value) {
+  assertSettablePath(path)
+  const { parent, key } = navigate(item, path, { create: true })
+  parent[key] = value
+  return item
+}
+
+/** Delete `item.<path>`. Errors if the key is absent (surfaces a state mismatch). */
+export function deleteAtPath(item, path) {
+  assertSettablePath(path)
+  const { parent, key } = navigate(item, path, { create: false })
+  if (!parent || !(key in parent)) {
+    throw new Error(`can't delete '${path}': it is not set`)
+  }
+  delete parent[key]
+  return item
+}
+
+function assertRelatableName(relname) {
+  if (relname === 'author') {
+    throw new Error(`the 'author' relation is set automatically when signing and can't be changed`)
+  }
+}
+
+/**
+ * Append `{ ref: target, ... }` to `item.relations[relname]`, deduping by ref.
+ * When the target is already present: updates its instruction/url if given,
+ * otherwise throws "already related" (silent success would hide a mistake).
+ */
+export function addRelation(item, relname, target, { instruction, url } = {}) {
+  assertRelatableName(relname)
+  assertValidRef(target)
+
+  item.relations = item.relations || {}
+  const arr = item.relations[relname] || (item.relations[relname] = [])
+  const existing = arr.find(e => e && e.ref === target)
+
+  if (existing) {
+    if (instruction === undefined && url === undefined) {
+      throw new Error(`already related: ${item.ref} already has ${relname} → ${target}. ` +
+        `Pass --instruction or --url to update it, or 'ig unrelate' to remove it first.`)
+    }
+    if (instruction !== undefined) existing.instruction = instruction
+    if (url !== undefined) existing.url = url
+    return { updated: true }
+  }
+
+  arr.push({
+    ref: target,
+    ...(instruction !== undefined ? { instruction } : {}),
+    ...(url !== undefined ? { url } : {})
+  })
+  return { added: true }
+}
+
+/**
+ * Remove the `target` entry from `item.relations[relname]`. Errors if it isn't
+ * there. Drops the relation key entirely when its array empties.
+ */
+export function removeRelation(item, relname, target) {
+  assertRelatableName(relname)
+  assertValidRef(target)
+
+  const arr = item.relations?.[relname]
+  const idx = arr ? arr.findIndex(e => e && e.ref === target) : -1
+  if (idx === -1) {
+    throw new Error(`not related: ${item.ref} has no ${relname} → ${target}. Nothing to remove.`)
+  }
+  arr.splice(idx, 1)
+  if (arr.length === 0) delete item.relations[relname]
+  return { removed: true }
+}
+
+/**
+ * Collect malformed-ref errors across every relation entry (commit stage 7).
+ * @returns {string[]} one message per malformed ref, with its JSON path.
+ */
+export function relationRefErrors(item) {
+  const errors = []
+  for (const [rel, entries] of Object.entries(item.relations || {})) {
+    if (!Array.isArray(entries)) continue
+    entries.forEach((e, i) => {
+      const ref = e && e.ref
+      if (!isValidRef(ref)) {
+        errors.push(`relations.${rel}[${i}].ref is malformed: expected <pubkey>.<uuid>` +
+          (typeof ref === 'string' ? ` (got '${ref}')` : ''))
+      }
+    })
+  }
+  return errors
+}

--- a/src/scaffold.js
+++ b/src/scaffold.js
@@ -82,6 +82,19 @@ export function scaffoldContent(schema) {
 }
 
 /**
+ * Pick the sub-schema describing `content`. TYPE schemas are item-level
+ * (validated against the whole item), so the content schema normally lives at
+ * `properties.content`. Fall back to treating the schema itself as the content
+ * schema for TYPEs that describe content directly.
+ * @param {object} [schema]
+ */
+export function contentSchemaOf(schema) {
+  if (!schema) return undefined
+  if (schema.properties && schema.properties.content) return schema.properties.content
+  return schema
+}
+
+/**
  * Scaffold a full draft object from a fetched TYPE.
  * @param {object} args
  * @param {object} args.typeObj - the fetched TYPE envelope ({ item: { content: { name, schema } } })
@@ -98,7 +111,7 @@ export function buildDraft({ typeObj, typeRef, identityName, realm }) {
     type: typeName,
     name: '<replace: short human-readable label>',
     instruction: '<replace: how an agent should interpret and display this object>',
-    content: scaffoldContent(schema),
+    content: scaffoldContent(contentSchemaOf(schema)),
     relations: {
       type_def: [{ ref: typeRef }],
       root: [{ ref: ROOT_REF, url: `https://dataverse001.net/${ROOT_REF}`, instruction: ROOT_INSTRUCTION }]

--- a/src/scaffold.js
+++ b/src/scaffold.js
@@ -1,0 +1,113 @@
+/**
+ * Scaffold a draft spec from a TYPE definition (`ig new`).
+ *
+ * Pure functions: turn a TYPE's `content.schema` (JSON Schema subset) into a
+ * draft object an author edits, then hands to `ig commit`. Placeholder values
+ * are written for a small model to recognise and replace correctly.
+ */
+
+import { ROOT_REF } from './identity.js'
+
+const ROOT_INSTRUCTION = "dataverse001 data-format. Read this first if you haven't yet."
+
+/** First concrete (non-null) type in a schema's `type`, or undefined. */
+function primaryType(schema) {
+  const t = schema?.type
+  if (Array.isArray(t)) return t.find(x => x !== 'null')
+  return t
+}
+
+/**
+ * A placeholder value for one property, derived from its schema.
+ * @param {object} propSchema
+ * @param {object} [opts]
+ * @param {boolean} [opts.optional] - mark the placeholder as optional (string/enum only)
+ */
+export function placeholderFor(propSchema = {}, { optional = false } = {}) {
+  const mark = optional ? 'optional ' : ''
+
+  if (Array.isArray(propSchema.enum) && propSchema.enum.length > 0) {
+    return `<${optional ? 'optional; ' : ''}one of: ${propSchema.enum.join(' | ')}>`
+  }
+
+  switch (primaryType(propSchema)) {
+    case 'integer':
+    case 'number':
+      return 0
+    case 'boolean':
+      return false
+    case 'null':
+      return null
+    case 'array': {
+      // One example element for scalar item schemas; object/array items stay empty (avoid deep nesting).
+      const items = propSchema.items
+      const itemType = primaryType(items)
+      if (items && itemType && itemType !== 'object' && itemType !== 'array') {
+        return [placeholderFor(items)]
+      }
+      return []
+    }
+    case 'object':
+      return propSchema.properties ? scaffoldContent(propSchema) : {}
+    case 'string':
+    default: {
+      const desc = propSchema.description || 'replace me'
+      return `<${mark}string: ${desc}>`
+    }
+  }
+}
+
+/**
+ * Build a `content` stub from an object schema: every property present,
+ * required ones first, each with a type-appropriate placeholder.
+ * @param {object} schema
+ */
+export function scaffoldContent(schema) {
+  if (!schema || !schema.properties) return {}
+  const required = new Set(schema.required || [])
+  const keys = Object.keys(schema.properties)
+  // Required first, in the schema author's stated order; then remaining optional properties.
+  const requiredInProps = (schema.required || []).filter(k => k in schema.properties)
+  const ordered = [...requiredInProps, ...keys.filter(k => !required.has(k))]
+
+  const content = {}
+  for (const key of ordered) {
+    content[key] = placeholderFor(schema.properties[key], { optional: !required.has(key) })
+  }
+  // Required keys the schema forgot to describe in `properties` still need to appear.
+  for (const key of required) {
+    if (!(key in content)) content[key] = '<string: required, replace me>'
+  }
+  return content
+}
+
+/**
+ * Scaffold a full draft object from a fetched TYPE.
+ * @param {object} args
+ * @param {object} args.typeObj - the fetched TYPE envelope ({ item: { content: { name, schema } } })
+ * @param {string} args.typeRef - the TYPE's ref (for the type_def relation and _draft)
+ * @param {string} [args.identityName] - recorded in _draft when supplied
+ * @param {string} [args.realm] - recorded in _draft when supplied
+ * @returns {object} draft spec (includes a _draft metadata block)
+ */
+export function buildDraft({ typeObj, typeRef, identityName, realm }) {
+  const schema = typeObj?.item?.content?.schema
+  const typeName = typeObj?.item?.content?.name || ''
+
+  return {
+    type: typeName,
+    name: '<replace: short human-readable label>',
+    instruction: '<replace: how an agent should interpret and display this object>',
+    content: scaffoldContent(schema),
+    relations: {
+      type_def: [{ ref: typeRef }],
+      root: [{ ref: ROOT_REF, url: `https://dataverse001.net/${ROOT_REF}`, instruction: ROOT_INSTRUCTION }]
+    },
+    _draft: {
+      mode: 'new',
+      type_ref: typeRef,
+      ...(identityName ? { identity: identityName } : {}),
+      ...(realm ? { realm } : {})
+    }
+  }
+}

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -261,6 +261,56 @@ describe('client', () => {
     })
   })
 
+  describe('buildUpdate() — compute an update without publishing', () => {
+    it('returns the merged item and original, and does NOT store', async () => {
+      const store = createMockStore()
+      const ig = createClient({
+        store,
+        identity: { type: 'credentials', username: 'bu-test', password: 'bu-test-pw' }
+      })
+      await ig.ready
+
+      const ref = await ig.create({ type: 'POST', content: { title: 'Original', meta: { author: 'Alice' } } })
+      const before = await store.get(ref)
+
+      const { item, orig } = await ig.buildUpdate(ref, { content: { meta: { version: 2 } } })
+      // Deep-merge semantics, immutables preserved, revision bumped
+      assert.equal(item.content.title, 'Original')
+      assert.equal(item.content.meta.author, 'Alice')
+      assert.equal(item.content.meta.version, 2)
+      assert.equal(item.id, orig.id)
+      assert.equal(item.revision, 1)
+
+      // Store is untouched — buildUpdate never publishes
+      const after = await store.get(ref)
+      assert.equal(after.item.revision ?? 0, before.item.revision ?? 0)
+      assert.ok(!after.item.content.meta.version, 'store not mutated')
+    })
+
+    it('supports the patch-function form', async () => {
+      const store = createMockStore()
+      const ig = createClient({ store, identity: { type: 'credentials', username: 'bu2', password: 'bu2-pw' } })
+      await ig.ready
+      const ref = await ig.create({ type: 'NOTE', content: { text: 'a' } })
+      const { item } = await ig.buildUpdate(ref, cur => { cur.content.text = 'b'; return cur })
+      assert.equal(item.content.text, 'b')
+    })
+
+    it('rejects updates to objects owned by someone else', async () => {
+      const store = createMockStore({
+        'FAKEPUBKEY.11111111-1111-1111-1111-111111111111': {
+          item: { id: '11111111-1111-1111-1111-111111111111', ref: 'FAKEPUBKEY.11111111-1111-1111-1111-111111111111', pubkey: 'FAKEPUBKEY', type: 'POST', content: {} }
+        }
+      })
+      const ig = createClient({ store, identity: { type: 'credentials', username: 'bu3', password: 'bu3-pw' } })
+      await ig.ready
+      await assert.rejects(
+        () => ig.buildUpdate('FAKEPUBKEY.11111111-1111-1111-1111-111111111111', { content: { x: 1 } }),
+        /your own objects/
+      )
+    })
+  })
+
   describe('createIdentity with PEM persistence', () => {
     it('generates keypair, publishes IDENTITY, saves PEM to disk', async () => {
       const tmpDir = join(tmpdir(), `ig-identity-test-${Date.now()}`)

--- a/test/draft.test.js
+++ b/test/draft.test.js
@@ -1,0 +1,78 @@
+/**
+ * Unit tests for src/draft.js — draft parsing/envelope checks behind `ig commit`.
+ */
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  parseDraftJSON, extractDraft, envelopeErrors, resolveCommitTarget, ALLOWED_TOP_LEVEL
+} from '../src/draft.js'
+
+describe('parseDraftJSON', () => {
+  it('parses valid JSON', () => {
+    assert.deepEqual(parseDraftJSON('{"a":1}'), { a: 1 })
+  })
+  it('reports line and column on a syntax error', () => {
+    assert.throws(() => parseDraftJSON('{\n  "a": 1,\n  bad\n}'), /line \d+ column \d+/)
+  })
+})
+
+describe('extractDraft', () => {
+  it('splits _draft from the signed payload', () => {
+    const { draft, payload } = extractDraft({ type: 'POST', _draft: { mode: 'new' }, content: {} })
+    assert.deepEqual(draft, { mode: 'new' })
+    assert.ok(!('_draft' in payload))
+    assert.equal(payload.type, 'POST')
+  })
+  it('returns null draft when absent', () => {
+    const { draft } = extractDraft({ type: 'POST' })
+    assert.equal(draft, null)
+  })
+})
+
+describe('envelopeErrors', () => {
+  it('accepts a payload of only allowed fields', () => {
+    assert.deepEqual(envelopeErrors({ type: 'POST', name: 'x', content: {}, relations: {} }), [])
+  })
+  it('flags unknown top-level fields and lists the allowed set', () => {
+    const errors = envelopeErrors({ type: 'POST', titel: 'typo' })
+    assert.equal(errors.length, 1)
+    assert.match(errors[0], /titel/)
+    assert.match(errors[0], /allowed/)
+  })
+  it('flags signature-managed fields with a remove hint', () => {
+    const errors = envelopeErrors({ type: 'POST', pubkey: 'x', signature: 'y' })
+    assert.equal(errors.length, 2)
+    assert.ok(errors.every(e => /remove/.test(e)))
+  })
+  it('exposes the allowed field set (checkout payloads pass)', () => {
+    for (const f of ['id', 'created_at', 'updated_at', 'revision', 'in']) {
+      assert.ok(ALLOWED_TOP_LEVEL.has(f), f)
+    }
+    assert.deepEqual(envelopeErrors({ id: 'x', in: ['r'], created_at: 't', revision: 2, type: 'POST', content: {} }), [])
+  })
+})
+
+describe('resolveCommitTarget', () => {
+  it('CLI flags win over _draft values', () => {
+    const r = resolveCommitTarget({
+      draft: { identity: 'draftId', realm: 'draftRealm' },
+      flagIdentity: 'flagId', flagRealm: 'flagRealm', activeIdentity: 'active', defaultRealm: 'def'
+    })
+    assert.equal(r.identity, 'flagId')
+    assert.equal(r.realm, 'flagRealm')
+    assert.equal(r.identitySource, 'flag')
+  })
+  it('falls back to _draft when no flag', () => {
+    const r = resolveCommitTarget({ draft: { identity: 'draftId', realm: 'draftRealm' }, activeIdentity: 'active', defaultRealm: 'def' })
+    assert.equal(r.identity, 'draftId')
+    assert.equal(r.identitySource, 'draft')
+    assert.equal(r.realm, 'draftRealm')
+  })
+  it('falls back to the active identity / default realm, flagging the fallback', () => {
+    const r = resolveCommitTarget({ draft: null, activeIdentity: 'active', defaultRealm: 'def' })
+    assert.equal(r.identity, 'active')
+    assert.equal(r.identitySource, 'fallback')
+    assert.equal(r.realm, 'def')
+    assert.equal(r.realmSource, 'fallback')
+  })
+})

--- a/test/patch-ops.test.js
+++ b/test/patch-ops.test.js
@@ -1,0 +1,133 @@
+/**
+ * Unit tests for src/patch-ops.js — pure item mutations behind
+ * `ig set` / `ig relate` / `ig unrelate` and the commit relation checks.
+ */
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  isValidRef, assertValidRef, assertSettablePath,
+  setAtPath, deleteAtPath, addRelation, removeRelation, relationRefErrors
+} from '../src/patch-ops.js'
+
+const REF = 'AxyU5_5vWmP2tO_klN4UpbZzRsuJEvJTrdwdg_gODxZJ.00000000-0000-0000-0000-000000000000'
+const TARGET = 'ApWJVWXvVKIIMnH6CP6u8HUyU2gLvyYGnwRlgrWAUwcP.d3d1219a-e755-456c-b02b-3d81cd3bd303'
+
+describe('ref shape', () => {
+  it('accepts <pubkey>.<uuid>', () => {
+    assert.ok(isValidRef(REF))
+    assert.ok(isValidRef(TARGET))
+  })
+  it('rejects malformed refs', () => {
+    for (const bad of ['', 'no-dot', 'pubkey.not-a-uuid', 'short.00000000-0000-0000-0000-000000000000', REF + 'x']) {
+      assert.equal(isValidRef(bad), false, bad)
+    }
+    assert.throws(() => assertValidRef('bad'), /malformed ref/)
+  })
+})
+
+describe('assertSettablePath', () => {
+  it('refuses signature/envelope-managed paths', () => {
+    for (const p of ['id', 'ref', 'pubkey', 'revision', 'created_at', 'updated_at', 'signature']) {
+      assert.throws(() => assertSettablePath(p), /set automatically/, p)
+    }
+  })
+  it('refuses whole-relations edits and points at relate/unrelate', () => {
+    assert.throws(() => assertSettablePath('relations'), /ig relate/)
+    assert.throws(() => assertSettablePath('relations.author'), /ig relate/)
+    assert.throws(() => assertSettablePath('relations.likes'), /ig relate/)
+  })
+  it('allows content/name/instruction paths', () => {
+    assert.doesNotThrow(() => assertSettablePath('content.title'))
+    assert.doesNotThrow(() => assertSettablePath('name'))
+    assert.doesNotThrow(() => assertSettablePath('instruction'))
+  })
+})
+
+describe('setAtPath', () => {
+  it('sets a nested value, creating intermediate objects', () => {
+    const item = { content: {} }
+    setAtPath(item, 'content.meta.version', 2)
+    assert.equal(item.content.meta.version, 2)
+  })
+  it('sets a top-level field', () => {
+    const item = { content: {} }
+    setAtPath(item, 'name', 'Hello')
+    assert.equal(item.name, 'Hello')
+  })
+  it('throws when an intermediate is not an object', () => {
+    const item = { content: { title: 'x' } }
+    assert.throws(() => setAtPath(item, 'content.title.deep', 1), /not an object/)
+  })
+})
+
+describe('deleteAtPath', () => {
+  it('removes an existing key', () => {
+    const item = { content: { title: 'x', body: 'y' } }
+    deleteAtPath(item, 'content.body')
+    assert.deepEqual(item.content, { title: 'x' })
+  })
+  it('errors when the key is absent (state mismatch, no silent no-op)', () => {
+    const item = { content: { title: 'x' } }
+    assert.throws(() => deleteAtPath(item, 'content.missing'), /not set/)
+  })
+})
+
+describe('addRelation', () => {
+  it('creates the array and appends the entry', () => {
+    const item = { ref: REF, relations: {} }
+    addRelation(item, 'likes', TARGET)
+    assert.deepEqual(item.relations.likes, [{ ref: TARGET }])
+  })
+  it('carries instruction and url when supplied', () => {
+    const item = { ref: REF, relations: {} }
+    addRelation(item, 'cites', TARGET, { instruction: 'see also', url: 'https://x' })
+    assert.deepEqual(item.relations.cites, [{ ref: TARGET, instruction: 'see also', url: 'https://x' }])
+  })
+  it('errors "already related" on a duplicate with no new metadata', () => {
+    const item = { ref: REF, relations: { likes: [{ ref: TARGET }] } }
+    assert.throws(() => addRelation(item, 'likes', TARGET), /already related/)
+  })
+  it('updates instruction/url on an existing entry instead of erroring', () => {
+    const item = { ref: REF, relations: { likes: [{ ref: TARGET }] } }
+    addRelation(item, 'likes', TARGET, { instruction: 'updated' })
+    assert.equal(item.relations.likes[0].instruction, 'updated')
+  })
+  it('refuses the author relation', () => {
+    assert.throws(() => addRelation({ ref: REF, relations: {} }, 'author', TARGET), /author/)
+  })
+  it('validates the target ref shape', () => {
+    assert.throws(() => addRelation({ ref: REF, relations: {} }, 'likes', 'bad'), /malformed ref/)
+  })
+})
+
+describe('removeRelation', () => {
+  it('removes an entry and drops the key when the array empties', () => {
+    const item = { ref: REF, relations: { likes: [{ ref: TARGET }] } }
+    removeRelation(item, 'likes', TARGET)
+    assert.ok(!('likes' in item.relations))
+  })
+  it('keeps other entries in the array', () => {
+    const other = 'ApWJVWXvVKIIMnH6CP6u8HUyU2gLvyYGnwRlgrWAUwcP.11111111-1111-1111-1111-111111111111'
+    const item = { ref: REF, relations: { likes: [{ ref: TARGET }, { ref: other }] } }
+    removeRelation(item, 'likes', TARGET)
+    assert.deepEqual(item.relations.likes, [{ ref: other }])
+  })
+  it('errors when the relation is absent (state mismatch)', () => {
+    assert.throws(() => removeRelation({ ref: REF, relations: {} }, 'likes', TARGET), /not related/)
+  })
+  it('refuses the author relation', () => {
+    assert.throws(() => removeRelation({ ref: REF, relations: { author: [{ ref: TARGET }] } }, 'author', TARGET), /author/)
+  })
+})
+
+describe('relationRefErrors', () => {
+  it('flags malformed refs with a JSON path, allows well-formed ones', () => {
+    const item = { relations: { author: [{ ref: REF }], cites: [{ ref: 'bad' }, { ref: TARGET }] } }
+    const errors = relationRefErrors(item)
+    assert.equal(errors.length, 1)
+    assert.match(errors[0], /relations\.cites\[0\]/)
+  })
+  it('returns [] for an item with no relations', () => {
+    assert.deepEqual(relationRefErrors({}), [])
+  })
+})

--- a/test/scaffold.test.js
+++ b/test/scaffold.test.js
@@ -1,0 +1,108 @@
+/**
+ * Unit tests for src/scaffold.js — schema → draft-spec scaffolding for `ig new`.
+ */
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { placeholderFor, scaffoldContent, buildDraft } from '../src/scaffold.js'
+import { ROOT_REF } from '../src/identity.js'
+
+describe('placeholderFor', () => {
+  it('strings carry a typed, described placeholder', () => {
+    assert.equal(placeholderFor({ type: 'string', description: 'the title' }), '<string: the title>')
+    assert.equal(placeholderFor({ type: 'string' }), '<string: replace me>')
+  })
+
+  it('optional strings are marked optional', () => {
+    assert.equal(placeholderFor({ type: 'string', description: 'a tag' }, { optional: true }), '<optional string: a tag>')
+  })
+
+  it('numbers, integers and booleans use typed zero-values', () => {
+    assert.equal(placeholderFor({ type: 'number' }), 0)
+    assert.equal(placeholderFor({ type: 'integer' }), 0)
+    assert.equal(placeholderFor({ type: 'boolean' }), false)
+  })
+
+  it('enums list the allowed values', () => {
+    assert.equal(placeholderFor({ enum: ['a', 'b', 'c'] }), '<one of: a | b | c>')
+  })
+
+  it('arrays of scalars include one example element; object arrays stay empty', () => {
+    assert.deepEqual(placeholderFor({ type: 'array', items: { type: 'string', description: 'a tag' } }), ['<string: a tag>'])
+    assert.deepEqual(placeholderFor({ type: 'array' }), [])
+    assert.deepEqual(placeholderFor({ type: 'array', items: { type: 'object' } }), [])
+  })
+
+  it('objects recurse into their properties, or empty when unspecified', () => {
+    assert.deepEqual(placeholderFor({ type: 'object' }), {})
+    assert.deepEqual(
+      placeholderFor({ type: 'object', required: ['x'], properties: { x: { type: 'integer' } } }),
+      { x: 0 }
+    )
+  })
+
+  it('picks the first non-null type from a type union', () => {
+    assert.equal(placeholderFor({ type: ['null', 'string'], description: 'maybe' }), '<string: maybe>')
+  })
+})
+
+describe('scaffoldContent', () => {
+  const schema = {
+    type: 'object',
+    required: ['title', 'count'],
+    properties: {
+      count: { type: 'integer' },
+      title: { type: 'string', description: 'headline' },
+      note: { type: 'string', description: 'aside' }
+    }
+  }
+
+  it('includes every property with the right placeholder type', () => {
+    const c = scaffoldContent(schema)
+    assert.equal(c.title, '<string: headline>')
+    assert.equal(c.count, 0)
+    assert.equal(c.note, '<optional string: aside>')
+  })
+
+  it('emits required properties before optional ones', () => {
+    const keys = Object.keys(scaffoldContent(schema))
+    assert.deepEqual(keys, ['title', 'count', 'note'])
+  })
+
+  it('a required key missing from properties still appears', () => {
+    const c = scaffoldContent({ type: 'object', required: ['ghost'], properties: {} })
+    assert.ok('ghost' in c)
+  })
+
+  it('returns {} when there is no property schema', () => {
+    assert.deepEqual(scaffoldContent(undefined), {})
+    assert.deepEqual(scaffoldContent({ type: 'object' }), {})
+  })
+})
+
+describe('buildDraft', () => {
+  const typeRef = 'AxyU5_5vWmP2tO_klN4UpbZzRsuJEvJTrdwdg_gODxZJ.ba52a919-af7f-460d-9606-6efb284ad9ae'
+  const typeObj = { item: { content: { name: 'POST', schema: { type: 'object', required: ['title'], properties: { title: { type: 'string' } } } } } }
+
+  it('scaffolds a full draft with type_def + root relations and a _draft block', () => {
+    const draft = buildDraft({ typeObj, typeRef, identityName: 'alt', realm: 'dataverse001' })
+    assert.equal(draft.type, 'POST')
+    assert.equal(draft.content.title, '<string: replace me>')
+    assert.equal(draft.relations.type_def[0].ref, typeRef)
+    assert.equal(draft.relations.root[0].ref, ROOT_REF)
+    assert.deepEqual(draft._draft, { mode: 'new', type_ref: typeRef, identity: 'alt', realm: 'dataverse001' })
+    assert.ok(typeof draft.name === 'string' && typeof draft.instruction === 'string')
+  })
+
+  it('omits identity/realm keys from _draft when not supplied', () => {
+    const draft = buildDraft({ typeObj, typeRef })
+    assert.deepEqual(draft._draft, { mode: 'new', type_ref: typeRef })
+  })
+
+  it('a TYPE without a schema still yields a minimal draft (empty content)', () => {
+    const noSchema = { item: { content: { name: 'FREEFORM' } } }
+    const draft = buildDraft({ typeObj: noSchema, typeRef })
+    assert.equal(draft.type, 'FREEFORM')
+    assert.deepEqual(draft.content, {})
+    assert.equal(draft.relations.type_def[0].ref, typeRef)
+  })
+})

--- a/test/scaffold.test.js
+++ b/test/scaffold.test.js
@@ -98,6 +98,20 @@ describe('buildDraft', () => {
     assert.deepEqual(draft._draft, { mode: 'new', type_ref: typeRef })
   })
 
+  it('scaffolds content from an item-level schema (properties.content)', () => {
+    const itemLevel = { item: { content: { name: 'RECIPE', schema: {
+      type: 'object',
+      required: ['instruction', 'content'],
+      properties: {
+        instruction: { type: 'string' },
+        content: { type: 'object', required: ['steps'], properties: { steps: { type: 'string', description: 'how to cook' } } }
+      }
+    } } } }
+    const draft = buildDraft({ typeObj: itemLevel, typeRef })
+    assert.equal(draft.content.steps, '<string: how to cook>')
+    assert.ok(!('instruction' in draft.content), 'item-level fields do not leak into content')
+  })
+
   it('a TYPE without a schema still yields a minimal draft (empty content)', () => {
     const noSchema = { item: { content: { name: 'FREEFORM' } } }
     const draft = buildDraft({ typeObj: noSchema, typeRef })

--- a/test/write-verbs.test.js
+++ b/test/write-verbs.test.js
@@ -444,4 +444,84 @@ describe('write verbs', () => {
       assert.match(e.stderr, /not related/)
     })
   })
+
+  // ─── Hardening (fixes from code review) ──────────────────────────
+
+  describe('hardening', () => {
+    const pubkey = async () => (await ig('identity')).stdout.match(/Pubkey: (\S+)/)[1]
+
+    it('ig new sanitizes a TYPE name so it cannot escape drafts/', async () => {
+      const evilType = join(projectDir, 'evil-type.json')
+      await writeFile(evilType, JSON.stringify({ type: 'TYPE', in: ['dataverse001'], content: { name: '../../pwned' } }))
+      const { stdout } = await ig('create', evilType)
+      const evilRef = stdout.trim().split('\n').pop()
+      const { stdout: p } = await ig('new', evilRef)
+      const rel = p.trim()
+      assert.ok(rel.startsWith('drafts/'), `draft stays under drafts/: ${rel}`)
+      assert.equal(rel.split('/').length, 2, 'no path separators beyond drafts/ — cannot escape the dir')
+      assert.ok(existsSync(join(projectDir, rel)), 'the draft was written inside the project drafts/ dir')
+    })
+
+    it('ig set errors on unquoted multi-word values (exit 2), not silent truncation', async () => {
+      const ref = await createObj({ type: 'POST', content: {} })
+      const e = await igFail('set', ref, 'content.title', 'Two', 'Words')
+      assert.equal(e.code, 2)
+      assert.match(e.stderr, /quote the value/)
+    })
+
+    it('ig commit strips a draft-supplied author relation, keeping the real signer', async () => {
+      const fake = 'ApWJVWXvVKIIMnH6CP6u8HUyU2gLvyYGnwRlgrWAUwcP.d3d1219a-e755-456c-b02b-3d81cd3bd303'
+      const id = '77777777-7777-7777-7777-777777777777'
+      const p = await writeDraft({
+        type: 'POST', id, in: ['dataverse001'], content: { title: 'x' },
+        relations: { author: [{ ref: fake }] }, _draft: { mode: 'new' }
+      })
+      const { stdout } = await ig('commit', p)
+      const ref = stdout.trim().split(' ')[1]
+      const author = stored.get(ref).item.relations.author
+      assert.equal(author[0].ref, `${await pubkey()}.00000000-0000-0000-0000-000000000001`, 'author is the signer identity, not the fake ref')
+    })
+
+    it('ig commit refuses a checkout draft combined with --update (exit 2)', async () => {
+      const ref = await createObj({ type: 'POST', content: { title: 'a' } })
+      const { stdout: e } = await ig('edit', ref)
+      const draftPath = join(projectDir, e.trim())
+      const err = await igFail('commit', draftPath, '--update', ref)
+      assert.equal(err.code, 2)
+      assert.match(err.stderr, /checkout/)
+    })
+
+    it('ig commit keeps the realm when a checkout draft omits "in"', async () => {
+      const ref = await createObj({ type: 'POST', content: { title: 'a' } })
+      const { stdout: e } = await ig('edit', ref)
+      const draftPath = join(projectDir, e.trim())
+      const draft = JSON.parse(await readFile(draftPath, 'utf-8'))
+      delete draft.in
+      draft.content.title = 'b'
+      await writeFile(draftPath, JSON.stringify(draft))
+      await ig('commit', draftPath)
+      assert.deepEqual(stored.get(ref).item.in, ['dataverse001'], 'realm preserved, object not orphaned')
+    })
+
+    it('ig commit does not delete a committed file outside ./drafts', async () => {
+      await mkdir(join(projectDir, 'sub', 'drafts'), { recursive: true })
+      const outside = join(projectDir, 'sub', 'drafts', 'keepme.json')
+      await writeFile(outside, JSON.stringify({ type: 'POST', in: ['dataverse001'], content: { title: 'keep' }, _draft: { mode: 'new' } }))
+      await ig('commit', outside)
+      assert.ok(existsSync(outside), 'a file under a non-cwd drafts/ dir is left in place')
+    })
+
+    it('flag-parse errors on write verbs use error:/exit 2', async () => {
+      const e = await igFail('new', typeRef, '--bogus-flag')
+      assert.equal(e.code, 2)
+      assert.match(e.stderr, /^error:/m)
+    })
+
+    it('a bad --identity on a write verb is error:/exit 2', async () => {
+      const p = await writeDraft({ type: 'POST', in: ['dataverse001'], content: {}, _draft: { mode: 'new' } })
+      const e = await igFail('commit', p, '--identity', 'nonexistent')
+      assert.equal(e.code, 2)
+      assert.match(e.stderr, /^error:/m)
+    })
+  })
 })

--- a/test/write-verbs.test.js
+++ b/test/write-verbs.test.js
@@ -1,0 +1,447 @@
+/**
+ * CLI integration tests for the write verbs: new, edit, commit, validate,
+ * set, relate, unrelate. Mirrors test/cli.test.js: mock hub + temp
+ * .instructionGraph dir, exercising exit codes and the stdout/stderr contract.
+ */
+import { describe, it, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import http from 'node:http'
+import { execFile as execFileCb } from 'node:child_process'
+import { promisify } from 'node:util'
+import { generateKeyPairSync } from 'node:crypto'
+import { mkdtemp, mkdir, writeFile, readFile, access, rm, readdir } from 'node:fs/promises'
+import { existsSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+const execFile = promisify(execFileCb)
+const CLI = join(import.meta.dirname, '..', 'cli', 'ig.js')
+
+async function readBody(req) {
+  const chunks = []
+  for await (const chunk of req) chunks.push(chunk)
+  return Buffer.concat(chunks).toString('utf-8')
+}
+
+describe('write verbs', () => {
+  let hub, projectDir, stored, typeRef, noSchemaRef
+
+  before(async () => {
+    stored = new Map()
+
+    const server = http.createServer(async (req, res) => {
+      const url = new URL(req.url, 'http://127.0.0.1')
+      const body = await readBody(req)
+      if (req.method === 'GET' && url.pathname === '/auth/challenge') {
+        res.writeHead(200, { 'Content-Type': 'application/json' })
+        return res.end(JSON.stringify({ challenge: 'wv-challenge', expires_at: '2099-01-01T00:00:00Z' }))
+      }
+      if (req.method === 'POST' && url.pathname === '/auth/token') {
+        res.writeHead(200, { 'Content-Type': 'application/json' })
+        return res.end(JSON.stringify({ token: 'wv-token', expires_at: '2099-01-02T00:00:00Z' }))
+      }
+      if (req.method === 'GET' && url.pathname === '/search') {
+        res.writeHead(200, { 'Content-Type': 'application/json' })
+        return res.end(JSON.stringify({ items: [...stored.values()], cursor: null }))
+      }
+      if (req.method === 'GET' && url.pathname.endsWith('/inbound')) {
+        res.writeHead(200, { 'Content-Type': 'application/json' })
+        return res.end(JSON.stringify({ items: [], cursor: null }))
+      }
+      if (req.method === 'GET' && stored.has(url.pathname.slice(1))) {
+        res.writeHead(200, { 'Content-Type': 'application/json' })
+        return res.end(JSON.stringify(stored.get(url.pathname.slice(1))))
+      }
+      if (req.method === 'PUT') {
+        const obj = JSON.parse(body)
+        // A test hook to force a hub push failure (for exit-4 coverage).
+        if (obj.item?.content?.failpush) {
+          res.writeHead(500, { 'Content-Type': 'application/json' })
+          return res.end(JSON.stringify({ error: 'forced push failure' }))
+        }
+        stored.set(url.pathname.slice(1), obj)
+        res.writeHead(201, { 'Content-Type': 'application/json' })
+        return res.end(body)
+      }
+      res.writeHead(404, { 'Content-Type': 'application/json' })
+      res.end(JSON.stringify({ error: 'not found' }))
+    })
+    await new Promise((resolve, reject) => {
+      server.listen(0, '127.0.0.1', () => resolve())
+      server.on('error', reject)
+    })
+    const { port } = server.address()
+    hub = { url: `http://127.0.0.1:${port}`, async close() { await new Promise(r => server.close(r)) } }
+
+    projectDir = await mkdtemp(join(tmpdir(), 'ig-wv-test-'))
+    const igDir = join(projectDir, '.instructionGraph')
+    await mkdir(join(igDir, 'config'), { recursive: true })
+    await mkdir(join(igDir, 'data'), { recursive: true }) // local store present → sync mode (as after `ig identity generate`)
+    await mkdir(join(igDir, 'identities', 'default'), { recursive: true })
+    await mkdir(join(igDir, 'identities', 'alt'), { recursive: true })
+    await writeFile(join(igDir, 'config', 'hub-url'), hub.url)
+    await writeFile(join(igDir, 'config', 'active-identity'), 'default')
+    await writeFile(join(igDir, 'config', 'default-realm'), 'dataverse001')
+    for (const name of ['default', 'alt']) {
+      const pem = generateKeyPairSync('ec', { namedCurve: 'prime256v1' })
+        .privateKey.export({ format: 'pem', type: 'pkcs8' }).toString()
+      await writeFile(join(igDir, 'identities', name, 'private.pem'), pem)
+    }
+
+    // A TYPE object with a schema (for `ig new` scaffolding + commit validation)
+    const typeSpec = join(projectDir, 'type-spec.json')
+    await writeFile(typeSpec, JSON.stringify({
+      type: 'TYPE', in: ['dataverse001'], name: 'NOTE type',
+      content: {
+        name: 'NOTE',
+        // Item-level schema: validated against the whole item; content lives under properties.content.
+        schema: { type: 'object', properties: {
+          content: { type: 'object', required: ['text', 'count'], properties: {
+            text: { type: 'string', description: 'the note body' },
+            count: { type: 'integer' },
+            tags: { type: 'array', items: { type: 'string', description: 'a tag' } }
+          } }
+        } }
+      }
+    }))
+    const { stdout: t } = await ig('create', typeSpec)
+    typeRef = t.trim().split('\n').pop()
+
+    // A TYPE-shaped object without a schema
+    const noSchemaSpec = join(projectDir, 'noschema-spec.json')
+    await writeFile(noSchemaSpec, JSON.stringify({ type: 'TYPE', in: ['dataverse001'], content: { name: 'FREEFORM' } }))
+    const { stdout: n } = await ig('create', noSchemaSpec)
+    noSchemaRef = n.trim().split('\n').pop()
+  })
+
+  after(async () => {
+    await hub.close()
+    await rm(projectDir, { recursive: true, force: true })
+  })
+
+  function ig(...args) {
+    return execFile('node', [CLI, ...args], {
+      cwd: projectDir,
+      env: { ...process.env, INSTRUCTIONGRAPH_DIR: join(projectDir, '.instructionGraph') }
+    })
+  }
+  /** Run ig expecting a non-zero exit; resolves with the error (code, stdout, stderr). */
+  async function igFail(...args) {
+    try { await ig(...args); throw new Error('expected non-zero exit') }
+    catch (e) { if (e.code === undefined) throw e; return e }
+  }
+
+  // ─── ig new ──────────────────────────────────────────────────────
+
+  describe('ig new', () => {
+    it('scaffolds a draft with schema-required props, type_def + root relations', async () => {
+      const { stdout } = await ig('new', typeRef)
+      const path = stdout.trim()
+      assert.ok(path.endsWith('.json'), 'stdout is the draft path')
+      const draft = JSON.parse(await readFile(join(projectDir, path), 'utf-8'))
+      assert.equal(draft.type, 'NOTE')
+      assert.equal(draft.content.text, '<string: the note body>')
+      assert.equal(draft.content.count, 0)
+      assert.deepEqual(draft.content.tags, ['<string: a tag>'])
+      assert.equal(draft.relations.type_def[0].ref, typeRef)
+      assert.ok(draft.relations.root[0].ref, 'has a root relation')
+      assert.equal(draft._draft.mode, 'new')
+      assert.equal(draft._draft.type_ref, typeRef)
+    })
+
+    it('records identity/realm from flags in _draft', async () => {
+      const { stdout } = await ig('new', typeRef, '--identity', 'alt', '--realm', 'dataverse001')
+      const draft = JSON.parse(await readFile(join(projectDir, stdout.trim()), 'utf-8'))
+      assert.equal(draft._draft.identity, 'alt')
+      assert.equal(draft._draft.realm, 'dataverse001')
+    })
+
+    it('never overwrites an existing draft (suffixes the name)', async () => {
+      const out = join(projectDir, 'fixed-draft.json')
+      const { stdout: a } = await ig('new', typeRef, '--out', out)
+      const { stdout: b } = await ig('new', typeRef, '--out', out)
+      assert.notEqual(a.trim(), b.trim())
+      assert.ok(existsSync(a.trim()) && existsSync(b.trim()))
+    })
+
+    it('a TYPE without a schema still scaffolds, with a stderr notice', async () => {
+      const { stdout, stderr } = await ig('new', noSchemaRef)
+      const draft = JSON.parse(await readFile(join(projectDir, stdout.trim()), 'utf-8'))
+      assert.deepEqual(draft.content, {})
+      assert.match(stderr, /no schema/i)
+    })
+
+    it('errors on a missing TYPE ref', async () => {
+      const missing = 'AxyU5_5vWmP2tO_klN4UpbZzRsuJEvJTrdwdg_gODxZJ.99999999-9999-9999-9999-999999999999'
+      const e = await igFail('new', missing)
+      assert.equal(e.code, 1)
+      assert.match(e.stderr, /error:/)
+    })
+
+    it('missing type-ref is a usage error (exit 2)', async () => {
+      const e = await igFail('new')
+      assert.equal(e.code, 2)
+    })
+  })
+
+  // Helpers for the verbs that operate on existing objects.
+  let draftSeq = 0
+  async function writeDraft(obj) {
+    const p = join(projectDir, `draft-${draftSeq++}.json`)
+    await writeFile(p, JSON.stringify(obj))
+    return p
+  }
+  /** Create a public object owned by the default identity; returns its ref. */
+  async function createObj(spec) {
+    const p = join(projectDir, `base-${draftSeq++}.json`)
+    await writeFile(p, JSON.stringify({ in: ['dataverse001'], ...spec }))
+    const { stdout } = await ig('create', p)
+    return stdout.trim().split('\n').pop()
+  }
+  const localItem = async (ref) => JSON.parse(await readFile(join(projectDir, '.instructionGraph', 'data', `${ref}.json`), 'utf-8')).item
+
+  // ─── ig edit ─────────────────────────────────────────────────────
+
+  describe('ig edit', () => {
+    it('checks out the latest revision with base_revision recorded', async () => {
+      const ref = await createObj({ type: 'POST', name: 'orig', content: { title: 'a' } })
+      const { stdout } = await ig('edit', ref)
+      const draft = JSON.parse(await readFile(join(projectDir, stdout.trim()), 'utf-8'))
+      assert.equal(draft._draft.mode, 'checkout')
+      assert.equal(draft._draft.base_ref, ref)
+      assert.equal(draft._draft.base_revision, 0)
+      assert.equal(draft.content.title, 'a')
+      assert.ok(!('pubkey' in draft) && !('ref' in draft), 'signature-managed fields stripped')
+    })
+
+    it('refuses an object owned by someone else', async () => {
+      const altP = join(projectDir, 'alt-obj.json')
+      await writeFile(altP, JSON.stringify({ type: 'POST', in: ['dataverse001'], content: { title: 'alt' } }))
+      const { stdout } = await ig('create', altP, '--identity', 'alt')
+      const altRef = stdout.trim().split('\n').pop()
+      const e = await igFail('edit', altRef)
+      assert.equal(e.code, 1)
+      assert.match(e.stderr, /can only edit your own objects/)
+    })
+  })
+
+  // ─── ig commit ───────────────────────────────────────────────────
+
+  describe('ig commit', () => {
+    it('creates a new object from a scaffold and consumes the drafts/ file', async () => {
+      const { stdout: p } = await ig('new', typeRef, '--out', join(projectDir, 'drafts', 'note.json'))
+      const draftPath = p.trim()
+      const { stdout, stderr } = await ig('commit', draftPath)
+      assert.match(stdout.trim(), /^committed \S+ rev 0 \(pushed\)$/)
+      assert.equal(stdout.trim().split('\n').length, 1, 'stdout is exactly the committed line')
+      const ref = stdout.trim().split(' ')[1]
+      assert.ok(stored.has(ref), 'pushed to hub')
+      assert.ok(!('_draft' in stored.get(ref).item), '_draft never appears in the signed item')
+      assert.ok(!existsSync(draftPath), 'consumed draft under drafts/ is deleted')
+    })
+
+    it('checkout-update increments the revision', async () => {
+      const ref = await createObj({ type: 'POST', name: 'orig', content: { title: 'v1' } })
+      const { stdout: e } = await ig('edit', ref)
+      const draftPath = join(projectDir, e.trim())
+      const draft = JSON.parse(await readFile(draftPath, 'utf-8'))
+      draft.content.title = 'v2'
+      await writeFile(draftPath, JSON.stringify(draft))
+      const { stdout } = await ig('commit', draftPath)
+      assert.match(stdout.trim(), new RegExp(`^committed ${ref} rev 1 \\(pushed\\)$`))
+      assert.equal(stored.get(ref).item.content.title, 'v2')
+    })
+
+    it('MERGE path (--update) preserves omitted top-level fields', async () => {
+      const ref = await createObj({ type: 'POST', name: 'keep-me', content: { title: 'v1', extra: 'stays' } })
+      const bare = await writeDraft({ content: { title: 'v2' } })
+      const { stdout } = await ig('commit', bare, '--update', ref)
+      assert.match(stdout.trim(), new RegExp(`^committed ${ref} rev 1`))
+      const item = stored.get(ref).item
+      assert.equal(item.name, 'keep-me', 'omitted top-level name preserved')
+      assert.equal(item.content.extra, 'stays', 'omitted content field preserved')
+      assert.equal(item.content.title, 'v2', 'patched field updated')
+    })
+
+    it('detects a revision conflict (exit 3)', async () => {
+      const ref = await createObj({ type: 'POST', content: { title: 'v1' } })
+      const { stdout: e } = await ig('edit', ref)
+      const stalePath = join(projectDir, e.trim())
+      await ig('set', ref, 'name', 'bumped') // advances to revision 1
+      const err = await igFail('commit', stalePath)
+      assert.equal(err.code, 3)
+      assert.match(err.stderr, /conflict/)
+      assert.match(err.stderr, /ig edit/)
+    })
+
+    it('rejects an unknown top-level field, naming it (exit 1)', async () => {
+      const p = await writeDraft({ type: 'POST', titel: 'typo', _draft: { mode: 'new' } })
+      const e = await igFail('commit', p)
+      assert.equal(e.code, 1)
+      assert.match(e.stderr, /titel/)
+    })
+
+    it('rejects signature-managed fields', async () => {
+      const p = await writeDraft({ type: 'POST', pubkey: 'x', _draft: { mode: 'new' } })
+      const e = await igFail('commit', p)
+      assert.equal(e.code, 1)
+      assert.match(e.stderr, /remove 'pubkey'/)
+    })
+
+    it('lists every schema error, one per line', async () => {
+      const p = await writeDraft({
+        type: 'NOTE', name: 'x', instruction: 'y', content: {},
+        relations: { type_def: [{ ref: typeRef }] }, _draft: { mode: 'new' }
+      })
+      const e = await igFail('commit', p)
+      assert.equal(e.code, 1)
+      assert.match(e.stderr, /text.*required/)
+      assert.match(e.stderr, /count.*required/)
+    })
+
+    it('--dry-run validates without touching the store', async () => {
+      const id = '55555555-5555-5555-5555-555555555555'
+      const p = await writeDraft({
+        type: 'NOTE', id, name: 'x', instruction: 'y', in: ['dataverse001'],
+        content: { text: 'hi', count: 1 },
+        relations: { type_def: [{ ref: typeRef }] }, _draft: { mode: 'new' }
+      })
+      const { stdout } = await ig('validate', p) // alias for commit --dry-run
+      assert.match(stdout.trim(), /^valid: would create /)
+      const ref = `${(await ig('identity')).stdout.match(/Pubkey: (\S+)/)[1]}.${id}`
+      assert.ok(!stored.has(ref), 'nothing pushed')
+      const dataDir = join(projectDir, '.instructionGraph', 'data')
+      assert.ok(!existsSync(join(dataDir, `${ref}.json`)), 'nothing stored')
+      const bk = existsSync(join(dataDir, 'bk')) ? await readdir(join(dataDir, 'bk')) : []
+      assert.ok(!bk.some(f => f.startsWith(ref)), 'no backup written for this object')
+    })
+
+    it('push failure stores locally and exits 4', async () => {
+      const id = '66666666-6666-6666-6666-666666666666'
+      const p = await writeDraft({ type: 'POST', id, in: ['dataverse001'], content: { failpush: true }, _draft: { mode: 'new' } })
+      const e = await igFail('commit', p, '--push')
+      assert.equal(e.code, 4)
+      assert.match(e.stderr, /push/)
+      assert.match(e.stderr, /ig server push --ref/)
+      const pubkey = (await ig('identity')).stdout.match(/Pubkey: (\S+)/)[1]
+      assert.ok(existsSync(join(projectDir, '.instructionGraph', 'data', `${pubkey}.${id}.json`)), 'stored locally')
+    })
+
+    it('errors when creating an object whose id already exists, pointing at ig edit', async () => {
+      const ref = await createObj({ type: 'POST', content: { title: 'first' } })
+      const id = ref.split('.').slice(1).join('.')
+      const p = await writeDraft({ type: 'POST', id, in: ['dataverse001'], content: { title: 'again' }, _draft: { mode: 'new' } })
+      const e = await igFail('commit', p)
+      assert.equal(e.code, 1)
+      assert.match(e.stderr, /already exists/)
+      assert.match(e.stderr, /ig edit/)
+    })
+
+    it('reports a JSON syntax error with line/column (exit 1)', async () => {
+      const p = join(projectDir, 'bad.json')
+      await writeFile(p, '{\n  "type": "POST",\n  bad\n}')
+      const e = await igFail('commit', p)
+      assert.equal(e.code, 1)
+      assert.match(e.stderr, /line \d+ column \d+/)
+    })
+  })
+
+  // ─── ig set ──────────────────────────────────────────────────────
+
+  describe('ig set', () => {
+    it('sets a nested path and bumps revision by exactly 1', async () => {
+      const ref = await createObj({ type: 'POST', content: { title: 'a' } })
+      const { stdout } = await ig('set', ref, 'content.title', 'b')
+      assert.match(stdout.trim(), new RegExp(`^committed ${ref} rev 1 \\(pushed\\)$`))
+      assert.equal(stored.get(ref).item.content.title, 'b')
+      await ig('set', ref, 'content.title', 'c')
+      assert.equal(stored.get(ref).item.revision, 2)
+    })
+
+    it('--json parses typed values', async () => {
+      const ref = await createObj({ type: 'POST', content: {} })
+      await ig('set', ref, 'content.score', '42', '--json')
+      assert.strictEqual(stored.get(ref).item.content.score, 42)
+      await ig('set', ref, 'content.tags', '["x","y"]', '--json')
+      assert.deepEqual(stored.get(ref).item.content.tags, ['x', 'y'])
+    })
+
+    it('--delete removes a key', async () => {
+      const ref = await createObj({ type: 'POST', content: { title: 'a', body: 'b' } })
+      await ig('set', ref, 'content.body', '--delete')
+      assert.ok(!('body' in stored.get(ref).item.content))
+    })
+
+    it('refuses signature-managed and relations paths (exit 1)', async () => {
+      const ref = await createObj({ type: 'POST', content: {} })
+      const e1 = await igFail('set', ref, 'pubkey', 'x')
+      assert.equal(e1.code, 1)
+      assert.match(e1.stderr, /set automatically/)
+      const e2 = await igFail('set', ref, 'relations.likes', 'x')
+      assert.equal(e2.code, 1)
+      assert.match(e2.stderr, /ig relate/)
+    })
+
+    it('usage error when neither value nor --delete is given (exit 2)', async () => {
+      const ref = await createObj({ type: 'POST', content: {} })
+      const e = await igFail('set', ref, 'content.title')
+      assert.equal(e.code, 2)
+    })
+  })
+
+  // ─── ig relate / ig unrelate ─────────────────────────────────────
+
+  describe('ig relate / ig unrelate', () => {
+    const TARGET = 'ApWJVWXvVKIIMnH6CP6u8HUyU2gLvyYGnwRlgrWAUwcP.d3d1219a-e755-456c-b02b-3d81cd3bd303'
+
+    it('adds a relation, creating the array', async () => {
+      const ref = await createObj({ type: 'POST', content: {} })
+      const { stdout } = await ig('relate', ref, 'cites', TARGET)
+      assert.match(stdout.trim(), new RegExp(`^committed ${ref} rev 1`))
+      assert.deepEqual(stored.get(ref).item.relations.cites, [{ ref: TARGET }])
+    })
+
+    it('errors "already related" on a duplicate (exit 1)', async () => {
+      const ref = await createObj({ type: 'POST', content: {} })
+      await ig('relate', ref, 'cites', TARGET)
+      const e = await igFail('relate', ref, 'cites', TARGET)
+      assert.equal(e.code, 1)
+      assert.match(e.stderr, /already related/)
+    })
+
+    it('updates instruction on an existing relation', async () => {
+      const ref = await createObj({ type: 'POST', content: {} })
+      await ig('relate', ref, 'cites', TARGET)
+      await ig('relate', ref, 'cites', TARGET, '--instruction', 'see also')
+      assert.equal(stored.get(ref).item.relations.cites[0].instruction, 'see also')
+    })
+
+    it('refuses the author relation (exit 1)', async () => {
+      const ref = await createObj({ type: 'POST', content: {} })
+      const e = await igFail('relate', ref, 'author', TARGET)
+      assert.equal(e.code, 1)
+      assert.match(e.stderr, /author/)
+    })
+
+    it('rejects a malformed target ref (exit 1)', async () => {
+      const ref = await createObj({ type: 'POST', content: {} })
+      const e = await igFail('relate', ref, 'cites', 'not-a-ref')
+      assert.equal(e.code, 1)
+      assert.match(e.stderr, /malformed ref/)
+    })
+
+    it('unrelate removes the entry and drops an emptied key', async () => {
+      const ref = await createObj({ type: 'POST', content: {} })
+      await ig('relate', ref, 'cites', TARGET)
+      await ig('unrelate', ref, 'cites', TARGET)
+      assert.ok(!('cites' in stored.get(ref).item.relations))
+    })
+
+    it('unrelate errors when the relation is absent (exit 1)', async () => {
+      const ref = await createObj({ type: 'POST', content: {} })
+      const e = await igFail('unrelate', ref, 'cites', TARGET)
+      assert.equal(e.code, 1)
+      assert.match(e.stderr, /not related/)
+    })
+  })
+})


### PR DESCRIPTION
Implements the approved spec `specs/20260707-ig-write-verbs.md` — explicit, synchronous, message-carrying write verbs so agents (especially small models) stop making avoidable mistakes writing dataverse objects.

## Verbs
- **`ig new <type-ref>`** — scaffold a draft from a TYPE's `content.schema` (typed placeholders, `type_def`+`root` relations, `_draft` block). No graph mutation.
- **`ig edit <ref>`** — check out the latest revision to a draft with `_draft{mode:checkout, base_ref, base_revision}`; refuses objects you don't own.
- **`ig commit <draft>`** — the single door in: parse (line/col JSON errors) → strip `_draft` → resolve identity/realm (flag > `_draft` > fallback, surfaced) → envelope checks → route (`new` create · `checkout` full-replace w/ conflict check · `--update` deep-**merge**) → schema validation (all errors) → relation-shape checks → `--dry-run` stop → sign/store/push → `committed <ref> rev N (pushed|local-only)`. Consumes a `drafts/` file on success.
- **`ig validate`** — alias for `commit --dry-run`.
- **`ig set <ref> <path> [value]`** — single-field patch (`--json`, `--delete`, refused managed/relations paths).
- **`ig relate` / `ig unrelate`** — relation add (dedupe: update-or-error) / remove (error-if-absent, drop-empty-key); `author` refused.
- **`ig server push --ref <ref>`** — per-object push (commit's exit-4 retry surface).

Fixes the known **`--update` wipes-omitted-fields** gotcha: the merge path preserves omitted top-level fields.

## Error contract (§4)
Exit codes `0` ok · `1` validation/parse/semantic · `2` usage · `3` revision conflict · `4` stored-locally-but-push-failed. Diagnostics on stderr prefixed `error:`; stdout carries only the machine-usable result line. Every message says what to do next.

## Design
Thin CLI wiring over existing library primitives. One small library addition — `client.buildUpdate(ref, patch)` factored out of `client.update` (behavior unchanged) — so the CLI can validate/inspect/report on the computed item while reusing the deep-merge/immutable/revision semantics. Pure, unit-tested modules: `src/scaffold.js`, `src/patch-ops.js`, `src/draft.js`.

## Testing
Strict TDD, temp-dir stores only (never touches a real store or hub). **Full suite: 299 pass** (was 209). Includes the merge-preserves-omitted regression, conflict (exit 3), dry-run untouched-store, push-failure (exit 4), and stdout/stderr separation. Reviewed with a multi-agent `/code-review` pass; **10 findings fixed** (filename-injection in `ig new`, draft-forged `author` relation, checkout dropping `in`, `set` multi-word truncation, over-broad `drafts/` auto-delete, write-verb `error:`/exit-2 contract on shared helpers, …), each with a regression test. By-hand e2e smoke: every verb, exit codes 0/1/2/3, contract confirmed.

Open-question decisions recorded in `specs/20260707-ig-write-verbs-deviations.md`.

## Out of scope / unchanged
`ig create` behavior unchanged (its `--help` gains a pointer to the new verbs).

🤖 Generated with [Claude Code](https://claude.com/code)