### PR TITLE
feat(git): fork + merge collaboration (ig git fork / ig git merge)

### DIFF
--- a/cli/ig.js
+++ b/cli/ig.js
@@ -1149,7 +1149,7 @@ async function main() {
         process.exit(r.status == null ? 1 : r.status)
       } else if (subcmd === 'fork') {
         validateFlags('git fork', args.slice(2), { valueFlags: ['identity', 'realm', 'name'] })
-        const rawRef = args[2] && !args[2].startsWith('-') ? args[2] : null
+        const [rawRef] = positionals(args.slice(2), ['identity', 'realm', 'name'])
         if (!rawRef) die('Usage: ig git fork <upstream-ref> [--name N] [--realm R]')
         const upstreamRef = rawRef.replace(/^ig::/, '').split('/')[0]
         const identityName = flag('identity')

--- a/cli/ig.js
+++ b/cli/ig.js
@@ -137,6 +137,8 @@ Commands:
   ig realm set <realm>                  Set a specific realm
   ig git init [name] [--realm R]        Create a git repository; prints its ref
   ig git clone <ref> [dir]              Clone a hosted repo (names dir after it)
+  ig git fork <upstream> [--name N]     Thin-fork a repo you can contribute to
+  ig git merge <fork> [branch]          Merge a fork branch into upstream (owner)
 
 Run 'ig <command> --help' for command-specific help.`)
   process.exit(0)
@@ -154,7 +156,7 @@ function commandUsage(command) {
     identity: `Usage: ig identity [generate|activate|list] [options]\n\nShow or manage the active identity.\n\nFlags:\n  --identity N  Show info for identity N instead of the active one\n\nSubcommands:\n  ig identity generate [--name N] [--project] [--activate]\n  ig identity activate <name>\n  ig identity list\n\nEnvironment:\n  INSTRUCTIONGRAPH_DIR  Override config directory location`,
     server: `Usage: ig server [set <url> | login | logout | remove | push]\n\nShow, configure, or remove the hub server connection.\n\nSubcommands:\n  ig server              Show current server status and auth\n  ig server set <url>    Connect to a hub server for sync\n  ig server login        Log in with your active identity\n  ig server logout       Log out from the hub\n  ig server remove       Disconnect and go offline\n  ig server push [--all]  Push local objects (default: your realms only)\n\nWithout a server, all data stays on local filesystem only.\nWith a server, objects sync between local storage and the hub.\nLogin uses your active identity (see ig identity).`,
     realm: `Usage: ig realm [set <realm|identity|dataverse001|server-public|local>]\n\nShow or set the default realm used for new objects.\n\n  ig realm set identity       Use current identity\'s realm (private)\n  ig realm set dataverse001   Use the public dataverse realm\n  ig realm set server-public  Public on this hub, not propagated globally\n  ig realm set local          Local only \u2014 never synced to any server\n  ig realm set <pubkey>       Use any specific realm`,
-    git: `Usage: ig git init [name] [--realm R] [--identity N]\n       ig git clone <ref> [dir] [--identity N]\n\nHost git repositories on instructionGraph (git-remote-ig helper).\n\ninit  Create a repository; prints its ref. Push/clone with:\n        git remote add origin ig::<ref> && git push -u origin main\n        git clone ig::<ref>/<name>\n      The /<name> suffix is ignored for resolution; it just gives stock git a\n      friendly checkout directory. Repo lives in your default realm unless\n      --realm is given. Only your identity can push; others fork to contribute.\n\nclone Clone a hosted repository, naming the checkout directory after the repo\n      (or [dir] if given).`,
+    git: `Usage: ig git init [name] [--realm R] [--identity N]\n       ig git clone <ref> [dir] [--identity N]\n       ig git fork <upstream-ref> [--name N] [--realm R] [--identity N]\n       ig git merge <fork-ref> [branch] [--into <upstream>] [--onto <refname>]\n                    [--ff-only | --no-ff] [--message M] [--identity N]\n\nHost git repositories on instructionGraph (git-remote-ig helper).\n\ninit  Create a repository; prints its ref. Push/clone with:\n        git remote add origin ig::<ref> && git push -u origin main\n        git clone ig::<ref>/<name>\n      The /<name> suffix is ignored for resolution; it just gives stock git a\n      friendly checkout directory. Repo lives in your default realm unless\n      --realm is given. Only your identity can push; others fork to contribute.\n\nclone Clone a hosted repository, naming the checkout directory after the repo\n      (or [dir] if given).\n\nfork  Thin-fork an upstream repo (O(1)): a new anchor with forked_from -> the\n      upstream plus a mirrored default branch, no objects copied. You own the\n      fork and can push to it; reads fall through to upstream. Inherits the\n      upstream realm unless --realm is given. Prints the fork ref.\n\nmerge Merge a fork branch back into an upstream you OWN (run from a clone of\n      the upstream, target branch checked out). Fetches the fork delta, runs\n      plain local git (fast-forward or, with --no-ff, a merge commit), signs\n      owner-copies of the new objects into your namespace (each carrying\n      copied_from -> the contributor's original), and CAS-updates the ref.\n      --into defaults to the fork's forked_from upstream; --onto to its\n      default branch. --ff-only refuses a non-fast-forward.`,
   }
 
   if (!docs[command]) die(`Unknown command: ${command}\nRun 'ig --help' for usage.`)
@@ -695,6 +697,67 @@ function printStatus({ isOnline, hubUrl }) {
   }
 }
 
+// ─── git merge (owner-side, client-computed) ─────────────────────
+
+/**
+ * `ig git merge <fork-ref> [branch] [--into <upstream>] [--onto <refname>]
+ *                          [--ff-only|--no-ff] [--message M] [--identity N]`
+ * Run from a clone of the upstream repo (target branch checked out). Delegates
+ * the mechanics to src/git/merge.js; here we only resolve args + the local git.
+ */
+async function gitMerge() {
+  validateFlags('git merge', args.slice(2), {
+    booleanFlags: ['ff-only', 'no-ff'],
+    valueFlags: ['identity', 'into', 'onto', 'message'],
+  })
+  const pos = positionals(args.slice(2), ['identity', 'into', 'onto', 'message'])
+  if (!pos[0]) {
+    die('Usage: ig git merge <fork-ref> [branch] [--into <upstream>] [--onto <refname>] [--ff-only|--no-ff]')
+  }
+  const sourceRef = pos[0].replace(/^ig::/, '').split('/')[0]
+  const sourceBranch = pos[1] || undefined
+  const ffOnly = args.includes('--ff-only')
+  const noFF = args.includes('--no-ff')
+  if (ffOnly && noFF) die('--ff-only and --no-ff are mutually exclusive.')
+  const mode = ffOnly ? 'ff-only' : noFF ? 'no-ff' : 'auto'
+
+  const identityName = flag('identity')
+  const hasIdentity = !!resolveIdentityConfig(findConfigDir())
+  const ctx = await makeClient({ identityName, authenticate: hasIdentity })
+  if (!ctx.client.pubkey) die('No identity configured — run \'ig identity generate\' first.')
+
+  const { resolveGitDir } = await import('../src/git/gitio.js')
+  const { execFileSync } = await import('node:child_process')
+  let gitDir, worktree
+  try {
+    gitDir = resolveGitDir()
+    worktree = execFileSync('git', ['rev-parse', '--show-toplevel']).toString('utf-8').trim()
+  } catch {
+    die('ig git merge must run inside a git working tree (a clone of the upstream repo).')
+  }
+
+  const into = flag('into')
+  const { mergeIntoUpstream } = await import('../src/git/merge.js')
+  const result = await mergeIntoUpstream({
+    client: ctx.client, gitDir, worktree,
+    sourceRef, sourceBranch,
+    upstreamRef: into ? into.replace(/^ig::/, '').split('/')[0] : undefined,
+    targetRefname: flag('onto'),
+    mode, message: flag('message'),
+  })
+
+  if (result.kind === 'up-to-date') {
+    console.error(`Already up to date (${result.targetRef} at ${result.base}).`)
+    return
+  }
+  console.log(result.newTip)
+  console.error(
+    `Merged (${result.kind}) into ${result.upstreamRef}\n` +
+    `  ${result.targetRef}: ${result.base || '(empty)'} → ${result.newTip}\n` +
+    `  signed ${result.copied.length} owner-copy object(s) into your namespace`
+  )
+}
+
 // ─── Commands ────────────────────────────────────────────────────
 
 /** Commands that skip makeClient and status line. */
@@ -1084,8 +1147,38 @@ async function main() {
         if (positional) cloneArgs.push(positional)
         const r = spawnSync('git', cloneArgs, { stdio: 'inherit' })
         process.exit(r.status == null ? 1 : r.status)
+      } else if (subcmd === 'fork') {
+        validateFlags('git fork', args.slice(2), { valueFlags: ['identity', 'realm', 'name'] })
+        const rawRef = args[2] && !args[2].startsWith('-') ? args[2] : null
+        if (!rawRef) die('Usage: ig git fork <upstream-ref> [--name N] [--realm R]')
+        const upstreamRef = rawRef.replace(/^ig::/, '').split('/')[0]
+        const identityName = flag('identity')
+        const realm = await resolveRealmAlias(flag('realm'), findConfigDir(), identityName)
+        // Reads may hit a private/shared upstream, so authenticate if we can.
+        const hasIdentity = !!resolveIdentityConfig(findConfigDir())
+        const ctx = await makeClient({ identityName, realm, authenticate: hasIdentity })
+        if (!ctx.client.pubkey) die('No identity configured — run \'ig identity generate\' first.')
+
+        const { forkRepo } = await import('../src/git/repo.js')
+        const { ref, tip, defaultBranch } = await forkRepo({
+          client: ctx.client,
+          upstreamRef,
+          name: flag('name'),
+          in: realm ? [realm] : undefined,
+        })
+        console.log(ref)
+        console.error(
+          `Forked ${upstreamRef}\n` +
+          `  ${defaultBranch} → ${tip || '(empty)'}\n` +
+          `Clone your fork, commit, and push:\n` +
+          `  git clone ig::${ref}\n` +
+          `  git push origin <branch>\n` +
+          `The upstream owner merges with: ig git merge ${ref} <branch>`
+        )
+      } else if (subcmd === 'merge') {
+        await gitMerge()
       } else {
-        die('Usage: ig git [init [name] [--realm R] | clone <ref> [dir]]')
+        die('Usage: ig git [init [name] [--realm R] | clone <ref> [dir] | fork <upstream> | merge <fork> [branch]]')
       }
       break
     }

--- a/notes/deviations.md
+++ b/notes/deviations.md
@@ -70,7 +70,35 @@ upstream's realm set so the upstream owner can still read the fork to merge it;
 shared-realm *member* may sign objects *into* that realm is a hub write-side semantics
 question we did not test here. The common v1 case (public upstream) is unaffected.
 
-## 7. Merge form (b) — MERGE_REQUEST as source — is plumbed but not exposed
+## 7. `copied_from` on multi-level fork chains merged cross-chain (known gap)
+
+`copied_from` is gated on `source.hasObjectLocal(oid)` — the *immediate* source
+fork's namespace, no fallthrough. For the flows the CLI actually produces this is
+exact: a direct fork C of upstream U, merged into U (the `forked_from` default), has
+its entire delta in C's namespace, so every copied object is attributed. The gap is
+narrow and deliberate: if you merge a **grandchild** fork straight into the
+grandparent (`U ← B ← C`, `ig git merge C --into U`), objects that C inherited from B
+(bytes stored only in B's namespace) are copied into U **without** `copied_from`.
+Chosen over the alternative (gating on `hasObject` *with* fallthrough), which would
+point `copied_from` at C's namespace where the object does not exist — a dangling,
+mis-attributing link, strictly worse than an omitted one. Accurate cross-chain
+attribution needs the resolver to report *which* namespace served each object;
+deferred as not worth the machinery for v1 (copied_from is optional provenance sugar,
+memo §3). Surfaced by codex adversarial review 2026-07-14.
+
+## 8. `base === null` merge (target branch absent) is not hardened
+
+When the upstream target branch does not exist yet (`base === null`), the stale-clone
+guard (local HEAD must equal the upstream tip) is skipped and the ref is created via
+`putRef(..., expectedOldOid: null)`. This is the intended path for merging into a
+fresh/empty upstream — now covered by a regression test (`test/git-merge.test.js`,
+"merge bootstraps content into an empty upstream"). Merging into a non-existent branch
+from a local checkout with an *unrelated* non-empty history is left to git's own
+`refusing to merge unrelated histories` protection rather than an explicit pre-check.
+The normal flow (merge into an existing upstream branch) always has `base` non-null and
+is fully guarded. Noted by review 2026-07-14; low severity, left as-is for v1.
+
+## 9. Merge form (b) — MERGE_REQUEST as source — is plumbed but not exposed
 
 `mergeIntoUpstream({ mergeRequestRef })` sets `merges` → the MR on the head/merge
 commit (native-mode form b), and `test/git-merge.test.js` exercises it directly. It is

--- a/notes/deviations.md
+++ b/notes/deviations.md
@@ -1,0 +1,81 @@
+# fork/merge — design notes & deviations from the Q5 memo
+
+Implementation notes for `ig git fork` / `ig git merge` (branch `feat/ig-fork-merge`,
+stacked on `feat/git-remote-ig`). Companion to the normative memo
+`~/projects/dataverse/specs/20260712-git-on-instructiongraph/open-question-5-merge-request-flow.md`.
+
+**Bottom line:** the memo's flow survived contact with the Phase 1 codebase intact.
+No core mechanic changed. Below are the small, deliberate decisions where the code
+had to pick something the memo left implicit, plus one memo-sanctioned looseness.
+
+## 1. The resolver fallthrough is the whole of Step 2's "real work" — confirmed
+
+Phase 1's push path already sends only the delta: `pushToRemote` derives
+`localKnownTips` from the fork's mirrored refs and excludes their closure via
+`git rev-list ^tip`. So once a *clone* of a thin fork can resolve upstream objects,
+delta push into a fork needs **zero** new push code. The net-new work was:
+`openRepo().getObject/hasObject` walking the `forked_from` chain (depth-first, array
+order, cycle-guarded), the O(1) fork anchor, and the merge provenance. Evidence:
+`test/git-fork.test.js` (fallthrough) and the thin-fork assertion in
+`test/git-fork-merge-e2e.test.js` (fork stores C2 but not C1).
+
+## 2. Relation sugar on fork delta-objects may dangle (memo-sanctioned)
+
+A fork's delta commit/tree carries `parent`/`tree`/`entry` relations computed in the
+**fork's** namespace, even when the target actually lives upstream (structural
+sharing). Those sugar links 404 on a naive follow. This is exactly the memo's
+"parsed mirrors / relation sugar are derived, never authoritative; may dangle after
+fork GC" stance (§2, README decision 3). The authoritative mechanism is the
+address-computed resolver (§1), which re-hashes every payload — so correctness never
+depends on the sugar. Left as-is by design; not worth an extra `hasObject` probe per
+relation at write time.
+
+## 3. `ig git merge` runs from the owner's working clone (matches "plain local git")
+
+The memo says merge is computed client-side by the owner with plain local git. The
+command therefore operates on the owner's checked-out clone of upstream (cwd = a work
+tree), fetches the fork delta into it, runs real `git merge --ff-only` / `--no-ff`,
+then signs owner-copies + CAS-updates the ref. Pragmatic precondition the memo did
+not spell out: **local HEAD of the target branch must equal the current upstream tip**
+(else the clone is stale and the CAS would fail anyway) — we fail early with a clear
+message instead. Conflicts abort the merge and tell the owner to resolve in a work
+tree / ask for a rebase (the memo's documented polite path); automated conflict
+resolution is out of v1 scope.
+
+## 4. HEAD stays implicit on forks (consistency with Phase 1)
+
+A fork is exactly **one anchor + one GIT_REF** (the mirrored default branch). HEAD is
+not stored as a GIT_REF — it is synthesized from `content.default_branch`, the same
+convention the rest of the system already uses (stock git never pushes HEAD, and
+`git-remote-ig`'s `list` synthesizes the `@refs/heads/… HEAD` line). Keeps the fork
+truly O(1).
+
+## 5. `copied_from` is set only where the fork actually stores the object
+
+Per memo §3, every owner-copy of a *contributor* object carries `copied_from` → the
+fork-namespace original. We gate this on `source.hasObjectLocal(oid)` (fork namespace,
+no fallthrough), so:
+- fork delta objects (C2/T2/B2) → `copied_from` set;
+- the owner-created **merge commit** M and its merged root tree → **no** `copied_from`
+  (they have no fork original), only `merges` → MR.
+This keeps `copied_from` from ever dangling onto owner-authored objects. Verified in
+`test/git-merge.test.js` (`--no-ff` case).
+
+## 6. Fork realm defaults to inheriting upstream's realm
+
+Per the memo's realm guidance (§2: "public upstream ⇒ public fork; shared-realm
+upstream ⇒ same shared realm"), `ig git fork` defaults the fork's `in` to the
+upstream's realm set so the upstream owner can still read the fork to merge it;
+`--realm` overrides. **Open question left unresolved** (memo open item 1): whether a
+shared-realm *member* may sign objects *into* that realm is a hub write-side semantics
+question we did not test here. The common v1 case (public upstream) is unaffected.
+
+## 7. Merge form (b) — MERGE_REQUEST as source — is plumbed but not exposed
+
+`mergeIntoUpstream({ mergeRequestRef })` sets `merges` → the MR on the head/merge
+commit (native-mode form b), and `test/git-merge.test.js` exercises it directly. It is
+**not** wired to a CLI flag yet: form (b) needs the AgentFlow-owned `MERGE_REQUEST`
+type extended with `source_repository`/`target_repository` relations + `base_oid`/
+`head_oid` (memo §2, open item 2). Per the task brief, that type re-sign is gated on
+owner (Tijs) approval — so the CLI implements form (a) (fork ref + branch) only, and
+form (b) is a small follow-up once the type lands.

--- a/notes/deviations.md
+++ b/notes/deviations.md
@@ -19,16 +19,23 @@ order, cycle-guarded), the O(1) fork anchor, and the merge provenance. Evidence:
 `test/git-fork.test.js` (fallthrough) and the thin-fork assertion in
 `test/git-fork-merge-e2e.test.js` (fork stores C2 but not C1).
 
-## 2. Relation sugar on fork delta-objects may dangle (memo-sanctioned)
+## 2. Relation sugar on fork delta-objects resolves across the graft point (tightened)
 
-A fork's delta commit/tree carries `parent`/`tree`/`entry` relations computed in the
-**fork's** namespace, even when the target actually lives upstream (structural
-sharing). Those sugar links 404 on a naive follow. This is exactly the memo's
-"parsed mirrors / relation sugar are derived, never authoritative; may dangle after
-fork GC" stance (§2, README decision 3). The authoritative mechanism is the
-address-computed resolver (§1), which re-hashes every payload — so correctness never
-depends on the sugar. Left as-is by design; not worth an extra `hasObject` probe per
-relation at write time.
+A fork's delta commit/tree references objects that may live either in the fork (the
+delta) or upstream (inherited via structural sharing). The memo sanctioned letting the
+`parent`/`tree`/`entry` sugar dangle at the graft point ("parsed mirrors / relation
+sugar are derived, never authoritative"). In practice that broke *"generic dataverse
+viewers walk history without git knowledge"* (README decision 3): the web viewer
+follows `relations` blindly and 404s at the fork boundary. So we tightened it (Tijs hit
+it on first fork, 2026-07-14): `objectRelations` and the GIT_REF `target` now route
+every referenced oid through `refAddr` → `openRepo().addrOf(oid)`, which points the
+relation at the namespace where the object actually resolves (fork-local for the delta,
+the first ancestor that stores it otherwise; falls back to local for same-push/absent
+oids). **Non-fork repos keep the previous zero-lookup fast path** (`forkedFrom.length`
+gate), so normal pushes are unaffected; only forks pay the classification reads
+(cached per open). Because git objects are immutable by oid, this fixes *future* fork
+pushes — objects written before the fix keep their original relations. Covered by
+`test/git-fork.test.js` ("fork delta relations resolve across the graft point").
 
 ## 3. `ig git merge` runs from the owner's working clone (matches "plain local git")
 

--- a/src/git/gitio.js
+++ b/src/git/gitio.js
@@ -59,6 +59,20 @@ export function runGit(gitDir, args, { input, maxBuffer = 256 * 1024 * 1024 } = 
   })
 }
 
+/**
+ * Run a git command inside a working tree (cwd = worktree, git auto-discovers
+ * GIT_DIR + index). Use for operations that need a work tree/index — e.g.
+ * `git merge` — where the GIT_DIR-only `runGit` would refuse.
+ */
+export function runGitWorktree(worktree, args, { input, maxBuffer = 256 * 1024 * 1024 } = {}) {
+  return execFileSync('git', args, {
+    cwd: worktree,
+    env: { ...process.env, GIT_NO_REPLACE_OBJECTS: '1' },
+    input,
+    maxBuffer,
+  })
+}
+
 /** The repository's object format ('sha1' | 'sha256'). */
 export function objectFormat(gitDir) {
   return runGit(gitDir, ['rev-parse', '--show-object-format']).toString('utf-8').trim()

--- a/src/git/merge.js
+++ b/src/git/merge.js
@@ -1,0 +1,168 @@
+/**
+ * Client-side merge of a fork branch into an upstream repository the caller
+ * owns. The hub never merges — only the owner's key can write the upstream
+ * namespace, so merge authority is namespace ownership (README decision 5).
+ *
+ * Runs in the owner's local git working tree (a clone of upstream with the
+ * target branch checked out at its current tip). Steps, per the Q5 memo:
+ *   1. fetch the source delta into local git (oids re-verified on read)
+ *   2. plain local git: fast-forward, or a merge commit (--no-ff)
+ *   3. sign owner-copies of the newly-reachable objects into the upstream
+ *      namespace — each carrying `copied_from` → the contributor's original,
+ *      and the head/merge commit carrying `merges` → the MERGE_REQUEST when one
+ *      is supplied (native-mode form)
+ *   4. CAS-update the target GIT_REF (compare the base tip, then revision++)
+ *
+ * Provenance rationale (memo §3, Option A): git authorship rides inside the
+ * commit payload byte-for-byte (same oid), so the owner's envelope signature is
+ * hosting attestation, not authorship — exactly what any git server does.
+ */
+
+import { parseRef } from '../object.js'
+import { openRepo } from './repo.js'
+import { fetchToLocal } from './transfer.js'
+import { objRef } from './addressing.js'
+import {
+  catFileBatch, revListObjectsWithPaths, revParse, isAncestor,
+  objectExists, runGitWorktree,
+} from './gitio.js'
+
+/** Normalize a branch argument to a full refname (refs/heads/<x> by default). */
+function fullBranch(name) {
+  return name.startsWith('refs/') ? name : `refs/heads/${name}`
+}
+
+/** First line of an error message (git errors are multi-line and noisy). */
+function firstLine(e) {
+  return (e?.stderr?.toString?.() || e?.message || String(e)).split('\n')[0]
+}
+
+/**
+ * @param {object} o
+ * @param {object} o.client - identity-bearing client (must own the upstream)
+ * @param {string} o.gitDir - the owner's local GIT_DIR
+ * @param {string} o.worktree - the owner's working-tree root (for `git merge`)
+ * @param {string} o.sourceRef - fork repo ref to merge from
+ * @param {string} [o.sourceBranch] - branch in the fork (default: its default branch)
+ * @param {string} [o.upstreamRef] - target repo ref (default: fork's forked_from)
+ * @param {string} [o.targetRefname] - branch to advance (default: upstream default branch)
+ * @param {'auto'|'ff-only'|'no-ff'} [o.mode='auto']
+ * @param {string} [o.message] - merge-commit message
+ * @param {string} [o.mergeRequestRef] - MERGE_REQUEST to record via `merges` (native mode)
+ * @returns {Promise<object>} summary
+ */
+export async function mergeIntoUpstream({
+  client, gitDir, worktree, sourceRef, sourceBranch,
+  upstreamRef, targetRefname, mode = 'auto', message, mergeRequestRef,
+}) {
+  if (!client?.pubkey) throw new Error('merge requires an identity-bearing client')
+
+  const source = await openRepo({ client, repoRef: sourceRef })
+  if (!source) throw new Error(`source repository not found: ${sourceRef}`)
+
+  const upRef = upstreamRef || source.forkedFrom?.[0]
+  if (!upRef) throw new Error('no upstream to merge into: the source is not a fork — pass --into <upstream-ref>')
+  const upstream = await openRepo({ client, repoRef: upRef })
+  if (!upstream) throw new Error(`upstream repository not found: ${upRef}`)
+
+  // Only the upstream owner can write its namespace — enforce before touching git.
+  const { pubkey: upOwner } = parseRef(upRef)
+  if (client.pubkey !== upOwner) {
+    throw new Error(
+      `cannot merge into ${upRef}: owned by ${upOwner}, active identity is ` +
+      `${client.pubkey || '(none)'} — only the owner can merge`
+    )
+  }
+
+  const targetRaw = targetRefname || upstream.content?.default_branch || 'refs/heads/main'
+  const targetRef = fullBranch(targetRaw)
+  const srcBranch = fullBranch(sourceBranch || source.content?.default_branch || 'refs/heads/main')
+
+  const srcRefObj = await source.getRef(srcBranch)
+  if (!srcRefObj?.targetOid) throw new Error(`source branch not found: ${srcBranch} in ${sourceRef}`)
+  const sourceTip = srcRefObj.targetOid
+
+  const base = (await upstream.getRef(targetRef))?.targetOid ?? null
+
+  // Materialize the source tip + ancestors locally (re-verifies every oid), and
+  // the base too, so rev-list ^base and git merge have everything they need.
+  await fetchToLocal({ repo: source, gitDir, wants: [sourceTip] })
+  if (base && !objectExists(gitDir, base)) {
+    await fetchToLocal({ repo: upstream, gitDir, wants: [base] })
+  }
+
+  // The local checkout must sit at the current upstream tip of the target branch
+  // (otherwise the owner's clone is stale and CAS would fail anyway).
+  if (base) {
+    const localHead = revParse(gitDir, 'HEAD')
+    if (localHead !== base) {
+      throw new Error(
+        `local HEAD ${localHead} is not at the current ${targetRef} tip ${base}; ` +
+        `check out the target branch and fetch first`
+      )
+    }
+  }
+
+  if (base && sourceTip === base) {
+    return { kind: 'up-to-date', base, newTip: base, copied: [], targetRef, upstreamRef: upRef }
+  }
+
+  const canFF = !base || isAncestor(gitDir, base, sourceTip)
+  if (mode === 'ff-only' && !canFF) {
+    throw new Error(`not a fast-forward (${targetRef} has diverged) — use --no-ff to create a merge commit`)
+  }
+
+  // ── plain local git: fast-forward, or a merge commit ──
+  let newTip, kind
+  if (canFF && mode !== 'no-ff') {
+    runGitWorktree(worktree, ['merge', '--ff-only', sourceTip])
+    kind = 'fast-forward'
+  } else {
+    const msg = message || `Merge ${sourceBranch || srcBranch} from ${sourceRef}`
+    try {
+      runGitWorktree(worktree, ['merge', '--no-ff', '-m', msg, sourceTip])
+    } catch (e) {
+      try { runGitWorktree(worktree, ['merge', '--abort']) } catch { /* nothing to abort */ }
+      throw new Error(
+        `merge produced conflicts — resolve them in a working tree (or ask the ` +
+        `contributor to rebase) and retry: ${firstLine(e)}`
+      )
+    }
+    kind = 'merge-commit'
+  }
+  newTip = revParse(gitDir, 'HEAD')
+
+  // ── copy the newly-reachable objects into the upstream namespace ──
+  const entries = revListObjectsWithPaths(gitDir, newTip, base ? [base] : [])
+  const recs = catFileBatch(gitDir, entries.map(e => e.oid))
+  const { pubkey: srcOwner, id: srcId } = parseRef(sourceRef)
+  const copied = []
+  for (const { oid, path } of entries) {
+    const rec = recs.get(oid)
+    if (!rec) throw new Error(`local object ${oid} missing after merge`)
+    const extra = {}
+    // Provenance sugar: point at the contributor's original iff the fork
+    // actually stores it (owner-created merge objects have no fork original).
+    if (await source.hasObjectLocal(oid)) {
+      extra.copied_from = [{ ref: await objRef(srcOwner, srcId, oid) }]
+    }
+    // The new head/merge commit records which MR it merges (native mode).
+    if (oid === newTip && mergeRequestRef) {
+      extra.merges = [{ ref: mergeRequestRef }]
+    }
+    const stored = await upstream.putObject(rec.type, rec.payload, {
+      name: path || undefined,
+      extraRelations: Object.keys(extra).length ? extra : undefined,
+    })
+    if (stored !== oid) throw new Error(`oid drift copying ${oid} → ${stored}`)
+    copied.push(oid)
+  }
+
+  // ── CAS the target ref base → newTip (signed reflog) ──
+  await upstream.putRef(targetRef, { targetOid: newTip }, { expectedOldOid: base })
+
+  return {
+    kind, base, newTip, copied, targetRef, upstreamRef: upRef,
+    sourceRef, sourceTip, mergeRequestRef: mergeRequestRef || null,
+  }
+}

--- a/src/git/merge.js
+++ b/src/git/merge.js
@@ -115,7 +115,17 @@ export async function mergeIntoUpstream({
   // ── plain local git: fast-forward, or a merge commit ──
   let newTip, kind
   if (canFF && mode !== 'no-ff') {
-    runGitWorktree(worktree, ['merge', '--ff-only', sourceTip])
+    // canFF only proves ancestry; the ff can still fail on a dirty tree, an
+    // untracked file that would be overwritten, or a stray index.lock. Surface
+    // an actionable message instead of a raw git dump (no --abort needed —
+    // --ff-only creates no merge state on failure).
+    try {
+      runGitWorktree(worktree, ['merge', '--ff-only', sourceTip])
+    } catch (e) {
+      throw new Error(
+        `fast-forward of ${targetRef} failed — is the working tree clean and on that branch? ${firstLine(e)}`
+      )
+    }
     kind = 'fast-forward'
   } else {
     const msg = message || `Merge ${sourceBranch || srcBranch} from ${sourceRef}`

--- a/src/git/repo.js
+++ b/src/git/repo.js
@@ -14,7 +14,7 @@ import { parseRef, makeRef } from '../object.js'
 import { ROOT_REF } from '../identity.js'
 import { payloadToContent, contentToPayload } from './codec.js'
 import { computeOid } from './oid.js'
-import { objId, objRef, refId } from './addressing.js'
+import { objId, refId } from './addressing.js'
 import { encodeRefContent, decodeRefContent } from './ref.js'
 import { TYPE_REFS, OTYPE_TO_TYPE, OTYPE_INSTRUCTION, REF_INSTRUCTION, repoInstruction } from './typerefs.js'
 
@@ -134,6 +134,22 @@ export async function openRepo({ client, repoRef, _seen = new Set() }) {
     return _parents
   }
 
+  // Address of a git object as *referenced from this repo's objects*. A plain
+  // repo just uses the local computed address (no lookups). On a thin fork a
+  // referenced object may live upstream (inherited, not part of the delta) —
+  // point the relation where the object actually resolves, so generic
+  // graph-walkers don't 404 at the graft point. Objects not found anywhere on
+  // the chain yet are part of this same push (or absent) → default to local.
+  // Cached per open; only forks pay the lookup.
+  const _refAddrCache = new Map()
+  async function refAddr(oid) {
+    if (!forkedFrom.length) return makeRef(owner, await objId(repoId, oid))
+    if (_refAddrCache.has(oid)) return _refAddrCache.get(oid)
+    const addr = (await api.addrOf(oid)) || makeRef(owner, await objId(repoId, oid))
+    _refAddrCache.set(oid, addr)
+    return addr
+  }
+
   // Child addresses are computed in the OWNER's namespace, but client.create
   // signs and addresses objects under the ACTIVE identity. They only coincide
   // when the active identity IS the owner — which the single-owner-push model
@@ -156,23 +172,23 @@ export async function openRepo({ client, repoRef, _seen = new Set() }) {
       type_def: [{ ref: TYPE_REFS[OTYPE_TO_TYPE[otype]] }],
     }
     if (otype === 'commit' && content.commit) {
-      if (content.commit.tree) relations.tree = [{ ref: await objRef(owner, repoId, content.commit.tree) }]
+      if (content.commit.tree) relations.tree = [{ ref: await refAddr(content.commit.tree) }]
       if (content.commit.parents?.length) {
         relations.parent = await Promise.all(
-          content.commit.parents.map(async p => ({ ref: await objRef(owner, repoId, p) }))
+          content.commit.parents.map(async p => ({ ref: await refAddr(p) }))
         )
       }
     } else if (otype === 'tree' && content.entries) {
       // Skip gitlink (160000) entries: those oids live in a submodule repo,
-      // not this namespace, so an objRef here would be wrong.
+      // not this namespace, so a ref here would be wrong.
       const linkable = content.entries.filter(e => e.mode !== '160000')
       if (linkable.length) {
         relations.entry = await Promise.all(
-          linkable.map(async e => ({ ref: await objRef(owner, repoId, e.oid), name: e.name }))
+          linkable.map(async e => ({ ref: await refAddr(e.oid), name: e.name }))
         )
       }
     } else if (otype === 'tag' && content.tag?.object) {
-      relations.target = [{ ref: await objRef(owner, repoId, content.tag.object) }]
+      relations.target = [{ ref: await refAddr(content.tag.object) }]
     }
     return relations
   }
@@ -224,6 +240,21 @@ export async function openRepo({ client, repoRef, _seen = new Set() }) {
       const addr = makeRef(owner, await objId(repoId, oid))
       const e = await client.get(addr)
       return !!(e?.item && e.item.type !== 'DELETED')
+    },
+
+    /**
+     * The address where `oid` resolves in this repo's fork graph: this
+     * namespace if stored here, else the first ancestor (depth-first) that has
+     * it; null if nowhere on the chain stores it. Lets relation sugar point at
+     * the live object instead of dangling at the graft point.
+     */
+    async addrOf(oid) {
+      if (await api.hasObjectLocal(oid)) return makeRef(owner, await objId(repoId, oid))
+      for (const p of await parents()) {
+        const a = await p.addrOf(oid)
+        if (a) return a
+      }
+      return null
     },
 
     /**
@@ -320,7 +351,7 @@ export async function openRepo({ client, repoRef, _seen = new Set() }) {
         repository: [{ ref: repoRef }],
         type_def: [{ ref: TYPE_REFS.GIT_REF }],
       }
-      if (targetOid) relations.target = [{ ref: await objRef(owner, repoId, targetOid) }]
+      if (targetOid) relations.target = [{ ref: await refAddr(targetOid) }]
 
       await client.create({
         type: 'GIT_REF', id, in: realms, content, relations,

--- a/src/git/repo.js
+++ b/src/git/repo.js
@@ -34,13 +34,19 @@ const MAX_OBJECT_BYTES = 7 * 1024 * 1024
  * @param {string[]} o.in - realm set inherited by every child
  * @param {string} [o.description]
  * @param {string} [o.defaultBranch]
+ * @param {string[]} [o.forkedFrom] - upstream repo ref(s) this repo is a thin fork of
  * @returns {Promise<string>} the repository ref
  */
-export async function initRepo({ client, id, name, format = 'sha1', in: realms, description, defaultBranch }) {
+export async function initRepo({ client, id, name, format = 'sha1', in: realms, description, defaultBranch, forkedFrom }) {
   if (!client?.pubkey) throw new Error('initRepo requires an identity-bearing client')
   const content = { name, object_format: format }
   if (description) content.description = description
   if (defaultBranch) content.default_branch = defaultBranch
+  const relations = {
+    type_def: [{ ref: TYPE_REFS.GIT_REPOSITORY }],
+    root: [{ ref: ROOT_REF }],
+  }
+  if (forkedFrom?.length) relations.forked_from = forkedFrom.map(ref => ({ ref }))
   return client.create({
     type: 'GIT_REPOSITORY',
     id,
@@ -48,11 +54,48 @@ export async function initRepo({ client, id, name, format = 'sha1', in: realms, 
     name, // item.name mirrors content.name (normative)
     content,
     instruction: repoInstruction(makeRef(client.pubkey, id)),
-    relations: {
-      type_def: [{ ref: TYPE_REFS.GIT_REPOSITORY }],
-      root: [{ ref: ROOT_REF }],
-    },
+    relations,
   })
+}
+
+/**
+ * Create a thin fork of an upstream repository (O(1)): a new GIT_REPOSITORY
+ * anchor signed by the active identity with `forked_from → upstream`, plus a
+ * single GIT_REF mirroring upstream's default branch at its current tip. No git
+ * objects are copied — reads fall through the `forked_from` chain (see openRepo).
+ *
+ * @param {object} o
+ * @param {object} o.client - identity-bearing client (the fork owner)
+ * @param {string} o.upstreamRef - "<owner>.<uuid>" of the repository to fork
+ * @param {string} [o.id] - fork uuid (default: fresh)
+ * @param {string} [o.name] - fork display name (default: upstream name)
+ * @param {string[]} [o.in] - realm set (default: inherit upstream's, so the
+ *   upstream owner can still read the fork to merge it)
+ * @returns {Promise<{ref:string, upstreamRef:string, name:string, in:string[], defaultBranch:string, tip:(string|null)}>}
+ */
+export async function forkRepo({ client, upstreamRef, id = crypto.randomUUID(), name, in: realms }) {
+  if (!client?.pubkey) throw new Error('forkRepo requires an identity-bearing client')
+  const upstream = await openRepo({ client, repoRef: upstreamRef })
+  if (!upstream) throw new Error(`upstream repository not found: ${upstreamRef}`)
+
+  const realmSet = realms || upstream.in
+  const forkName = name || upstream.content?.name || 'fork'
+  const defaultBranch = upstream.content?.default_branch || 'refs/heads/main'
+
+  const forkRef = await initRepo({
+    client, id, name: forkName, format: upstream.format,
+    in: realmSet, defaultBranch, forkedFrom: [upstreamRef],
+  })
+
+  // Mirror the upstream default branch at its current tip. HEAD stays implicit
+  // (synthesized from content.default_branch, as everywhere else), so the fork
+  // is one anchor + one ref. If upstream has no tip yet, the fork is empty too.
+  const fork = await openRepo({ client, repoRef: forkRef })
+  const upstreamDefault = await upstream.getRef(defaultBranch)
+  const tip = upstreamDefault?.targetOid ?? null
+  if (tip) await fork.putRef(defaultBranch, { targetOid: tip }, { expectedOldOid: null })
+
+  return { ref: forkRef, upstreamRef, name: forkName, in: realmSet, defaultBranch, tip }
 }
 
 /**
@@ -60,8 +103,13 @@ export async function initRepo({ client, id, name, format = 'sha1', in: realms, 
  * @param {object} o
  * @param {object} o.client
  * @param {string} o.repoRef - "<owner>.<uuid>"
+ * @param {Set<string>} [o._seen] - internal: repos already opened on this walk
+ *   (thin-fork fallthrough cycle guard; forked_from is self-asserted). Callers
+ *   should not pass this.
  */
-export async function openRepo({ client, repoRef }) {
+export async function openRepo({ client, repoRef, _seen = new Set() }) {
+  if (_seen.has(repoRef)) return null // already on this fork chain — break the cycle
+  _seen.add(repoRef)
   // Returns null only for a genuine not-found; a store/network/auth failure
   // propagates as an exception (callers must not treat those as "empty repo").
   const env = await client.get(repoRef)
@@ -70,6 +118,21 @@ export async function openRepo({ client, repoRef }) {
   const { pubkey: owner, id: repoId } = parseRef(repoRef)
   const format = repo.content?.object_format || 'sha1'
   const realms = repo.in
+  const forkedFrom = (repo.relations?.forked_from || []).map(r => r.ref).filter(Boolean)
+
+  // Upstream repositories this one thins over. Opened lazily and cached — the
+  // common repo stores nothing, so most reads never touch them; a thin fork
+  // touches them only on a local miss. Depth-first in forked_from array order.
+  let _parents = null
+  async function parents() {
+    if (_parents) return _parents
+    _parents = []
+    for (const up of forkedFrom) {
+      const p = await openRepo({ client, repoRef: up, _seen })
+      if (p) _parents.push(p)
+    }
+    return _parents
+  }
 
   // Child addresses are computed in the OWNER's namespace, but client.create
   // signs and addresses objects under the ACTIVE identity. They only coincide
@@ -138,8 +201,14 @@ export async function openRepo({ client, repoRef }) {
     in: realms,
     content: repo.content,
 
-    /** Fetch a git object by oid; verifies the oid on read. Null if absent. */
-    async getObject(oid) {
+    forkedFrom,
+    parents,
+
+    /**
+     * Fetch a git object from THIS repository's namespace only (no fork
+     * fallthrough); verifies the oid on read. Null if absent/deleted.
+     */
+    async getObjectLocal(oid) {
       const addr = makeRef(owner, await objId(repoId, oid))
       const e = await client.get(addr)
       if (!e?.item || e.item.type === 'DELETED') return null
@@ -150,19 +219,45 @@ export async function openRepo({ client, repoRef }) {
       return { otype, payload }
     },
 
-    /** True if the object already exists in the store. */
-    async hasObject(oid) {
+    /** True if THIS repository's namespace stores the object (no fallthrough). */
+    async hasObjectLocal(oid) {
       const addr = makeRef(owner, await objId(repoId, oid))
       const e = await client.get(addr)
       return !!(e?.item && e.item.type !== 'DELETED')
     },
 
     /**
+     * Fetch a git object, falling through the `forked_from` chain on a local
+     * miss (thin-fork resolution). Verifies the oid on read regardless of which
+     * namespace served the bytes. Null if no repo on the chain has it.
+     */
+    async getObject(oid) {
+      const local = await api.getObjectLocal(oid)
+      if (local) return local
+      for (const p of await parents()) {
+        const up = await p.getObject(oid)
+        if (up) return up
+      }
+      return null
+    },
+
+    /** True if this repo or any upstream on the fork chain has the object. */
+    async hasObject(oid) {
+      if (await api.hasObjectLocal(oid)) return true
+      for (const p of await parents()) {
+        if (await p.hasObject(oid)) return true
+      }
+      return false
+    },
+
+    /**
      * Write an immutable git object; idempotent. Returns its oid.
      * `name` is a best-effort first-seen path (for tree/blob) supplied by the
      * caller; commit/tag names are derived from the payload.
+     * `extraRelations` (e.g. `copied_from`, `merges`) are merged into the object's
+     * relations at creation — used by merge to record provenance on owner-copies.
      */
-    async putObject(otype, payload, { name } = {}) {
+    async putObject(otype, payload, { name, extraRelations } = {}) {
       requireOwner('write object')
       if (payload.length > MAX_OBJECT_BYTES) {
         throw new Error(
@@ -176,7 +271,7 @@ export async function openRepo({ client, repoRef }) {
       const addr = makeRef(owner, id)
       const existing = await client.get(addr)
       if (existing?.item && existing.item.type !== 'DELETED') return oid // immutable, already stored
-      const relations = await objectRelations(otype, content)
+      const relations = { ...(await objectRelations(otype, content)), ...(extraRelations || {}) }
       await client.create({
         type: OTYPE_TO_TYPE[otype], id, in: realms, content, relations,
         name: objectName(otype, content, name),

--- a/test-support/ig-store.js
+++ b/test-support/ig-store.js
@@ -24,6 +24,23 @@ export async function setupIgStore({ realm = 'server-public' } = {}) {
   return { dir, pubkey: id.pubkey, realm }
 }
 
+/**
+ * Add another identity to an existing store and return its pubkey. Lets tests
+ * model cross-identity flows (fork/merge) in one shared object store.
+ */
+export async function addIdentity(store, name) {
+  const id = await throwawayIdentity()
+  const idDir = join(store.dir, 'identities', name)
+  mkdirSync(idDir, { recursive: true })
+  writeFileSync(join(idDir, 'private.pem'), id.pem, { mode: 0o600 })
+  return id.pubkey
+}
+
+/** Switch the store's active identity (used by the git-remote-ig helper). */
+export function setActiveIdentity(store, name) {
+  writeFileSync(join(store.dir, 'config', 'active-identity'), `${name}\n`)
+}
+
 /** Write an executable `git-remote-ig` wrapper into a fresh dir; return the dir. */
 export function setupHelperOnPath() {
   const here = dirname(fileURLToPath(import.meta.url))

--- a/test/git-fork-merge-e2e.test.js
+++ b/test/git-fork-merge-e2e.test.js
@@ -93,7 +93,8 @@ function seedUpstream() {
 /** Bob forks, clones the fork, commits C2 on `feature`, pushes (thin). */
 function contributorFork(upstreamRef) {
   setActiveIdentity(store, 'bob')
-  const forkRef = ig(tmpdir(), ['git', 'fork', upstreamRef, '--name', 'fork', '--identity', 'bob']).trim()
+  // flags before the positional ref — guards the arg-order parse fix
+  const forkRef = ig(tmpdir(), ['git', 'fork', '--identity', 'bob', '--name', 'fork', upstreamRef]).trim()
 
   const clone = mkTmp('ig-fm-forkclone-')
   cleanup.push(clone)

--- a/test/git-fork-merge-e2e.test.js
+++ b/test/git-fork-merge-e2e.test.js
@@ -1,0 +1,196 @@
+/**
+ * End-to-end through REAL git across TWO identities: the whole collaboration
+ * loop from the Q5 memo —
+ *
+ *   owner: ig git init upstream + push C1
+ *   contributor: ig git fork → clone fork → commit C2 → push (thin: only C2)
+ *   owner: clone upstream → ig git merge <fork> feature
+ *   anyone: clone upstream → git fsck clean, history intact, C2 byte-identical
+ *
+ * Proves the resolver fallthrough (fork clone resolves C1 from upstream), the
+ * thin push (fork stores only its delta), and owner re-signed copies carrying
+ * `copied_from` provenance.
+ */
+
+import { test, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { execFileSync } from 'node:child_process'
+import { createHash } from 'node:crypto'
+import { rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { mkTmp } from '../test-support/git-fixture.js'
+import { setupIgStore, setupHelperOnPath, gitEnv, addIdentity, setActiveIdentity } from '../test-support/ig-store.js'
+
+const IG = fileURLToPath(new URL('../cli/ig.js', import.meta.url))
+
+let store, bindir, env, ownerPk, bobPk
+const cleanup = []
+
+before(async () => {
+  store = await setupIgStore({ realm: 'server-public' }) // active identity: 'default' (owner)
+  ownerPk = store.pubkey
+  bobPk = await addIdentity(store, 'bob')
+  bindir = setupHelperOnPath()
+  // Owner git identity: the person running `ig git merge --no-ff` has git
+  // configured. Explicit per-commit env (owner C1, Bob's commits) overrides this.
+  env = gitEnv(store, bindir, {
+    GIT_AUTHOR_NAME: 'Owner', GIT_AUTHOR_EMAIL: 'owner@example.com',
+    GIT_COMMITTER_NAME: 'Owner', GIT_COMMITTER_EMAIL: 'owner@example.com',
+  })
+  cleanup.push(store.dir, bindir)
+})
+after(() => { for (const d of cleanup) { try { rmSync(d, { recursive: true, force: true }) } catch {} } })
+
+/** Fixed git identity so the contributor's commit is byte-reproducible/assertable. */
+function bobGit(dir, args) {
+  return execFileSync('git', ['-C', dir, ...args], {
+    env: {
+      ...env,
+      GIT_AUTHOR_NAME: 'Bob Contributor', GIT_AUTHOR_EMAIL: 'bob@example.com',
+      GIT_AUTHOR_DATE: '1700001000 +0000',
+      GIT_COMMITTER_NAME: 'Bob Contributor', GIT_COMMITTER_EMAIL: 'bob@example.com',
+      GIT_COMMITTER_DATE: '1700001000 +0000',
+    },
+    maxBuffer: 1 << 26,
+  }).toString('utf-8')
+}
+function rgit(dir, args) {
+  return execFileSync('git', ['-C', dir, ...args], { env, maxBuffer: 1 << 26 }).toString('utf-8')
+}
+function ig(cwd, args) {
+  return execFileSync('node', [IG, ...args], { env, cwd, maxBuffer: 1 << 26 }).toString('utf-8')
+}
+/** True if `ig get <ref>` finds the object (exit 0); false on not-found (exit 1). */
+function igGetExists(ref, identity) {
+  try {
+    execFileSync('node', [IG, 'get', ref, '--identity', identity], { env, cwd: tmpdir(), stdio: ['ignore', 'pipe', 'pipe'] })
+    return true
+  } catch { return false }
+}
+
+/** Owner creates `upstream` with a single commit C1 (readme.md) on main. */
+function seedUpstream() {
+  setActiveIdentity(store, 'default')
+  const ref = ig(tmpdir(), ['git', 'init', 'upstream', '--realm', 'server-public']).trim()
+  const work = mkTmp('ig-fm-upstream-')
+  cleanup.push(work)
+  rgit(work, ['init', '-q', '-b', 'main'])
+  writeFileSync(join(work, 'readme.md'), 'hello world\n')
+  rgit(work, ['add', '-A'])
+  execFileSync('git', ['-C', work, 'commit', '-q', '-m', 'first commit'], {
+    env: { ...env, GIT_AUTHOR_NAME: 'Owner', GIT_AUTHOR_EMAIL: 'owner@example.com',
+      GIT_AUTHOR_DATE: '1700000000 +0000', GIT_COMMITTER_NAME: 'Owner',
+      GIT_COMMITTER_EMAIL: 'owner@example.com', GIT_COMMITTER_DATE: '1700000000 +0000' },
+  })
+  rgit(work, ['remote', 'add', 'origin', `ig::${ref}`])
+  rgit(work, ['push', 'origin', 'main'])
+  return { ref, c1: rgit(work, ['rev-parse', 'main']).trim() }
+}
+
+/** Bob forks, clones the fork, commits C2 on `feature`, pushes (thin). */
+function contributorFork(upstreamRef) {
+  setActiveIdentity(store, 'bob')
+  const forkRef = ig(tmpdir(), ['git', 'fork', upstreamRef, '--name', 'fork', '--identity', 'bob']).trim()
+
+  const clone = mkTmp('ig-fm-forkclone-')
+  cleanup.push(clone)
+  rmSync(clone, { recursive: true, force: true })
+  execFileSync('git', ['clone', '--quiet', `ig::${forkRef}`, clone], { env, cwd: tmpdir(), maxBuffer: 1 << 26 })
+
+  // resolver fallthrough proof: cloning the thin fork reconstructs C1's tree,
+  // whose objects live ONLY in the upstream namespace.
+  execFileSync('git', ['-C', clone, 'fsck', '--full', '--strict'], { env, maxBuffer: 1 << 26, stdio: ['ignore', 'pipe', 'pipe'] })
+  assert.equal(rgit(clone, ['show', 'HEAD:readme.md']), 'hello world\n', 'fork clone resolves upstream C1 content')
+
+  bobGit(clone, ['checkout', '-q', '-b', 'feature'])
+  writeFileSync(join(clone, 'readme.md'), 'hello world\nbob was here\n')
+  bobGit(clone, ['add', '-A'])
+  bobGit(clone, ['commit', '-q', '-m', 'bob: add a line'])
+  const c2 = rgit(clone, ['rev-parse', 'HEAD']).trim()
+  rgit(clone, ['push', 'origin', 'feature'])
+  return { forkRef, clone, c2 }
+}
+
+/** Owner clones upstream and returns the working copy dir. */
+function ownerCloneUpstream(upstreamRef) {
+  setActiveIdentity(store, 'default')
+  const work = mkTmp('ig-fm-ownerwork-')
+  cleanup.push(work)
+  rmSync(work, { recursive: true, force: true })
+  execFileSync('git', ['clone', '--quiet', `ig::${upstreamRef}`, work], { env, cwd: tmpdir(), maxBuffer: 1 << 26 })
+  return work
+}
+
+/** Fresh clone + fsck; returns the clone dir. */
+function verifyClone(upstreamRef, prefix) {
+  const clone = mkTmp(prefix)
+  cleanup.push(clone)
+  rmSync(clone, { recursive: true, force: true })
+  execFileSync('git', ['clone', '--quiet', `ig::${upstreamRef}`, clone], { env, cwd: tmpdir(), maxBuffer: 1 << 26 })
+  execFileSync('git', ['-C', clone, 'fsck', '--full', '--strict'], { env, maxBuffer: 1 << 26, stdio: ['ignore', 'pipe', 'pipe'] })
+  return clone
+}
+
+test('fast-forward merge: contributor commit lands in upstream byte-identically', () => {
+  const { ref: upstreamRef, c1 } = seedUpstream()
+  const { forkRef, c2 } = contributorFork(upstreamRef)
+
+  // thin fork: it stored ONLY its own delta — C1 is NOT in Bob's fork namespace
+  assert.equal(igGetExists(`${bobPk}.${uuidv5ObjSync(forkRef, c1)}`, 'bob'), false, 'fork does not store C1 (resolves it upstream)')
+  assert.equal(igGetExists(`${bobPk}.${uuidv5ObjSync(forkRef, c2)}`, 'bob'), true, 'fork stores its own delta commit C2')
+
+  const ownerWork = ownerCloneUpstream(upstreamRef)
+  setActiveIdentity(store, 'default')
+  const out = ig(ownerWork, ['git', 'merge', forkRef, 'feature', '--identity', 'default'])
+  assert.match(out.trim(), new RegExp(`^${c2}$`), 'merge prints the new upstream tip = C2 (ff)')
+
+  const clone = verifyClone(upstreamRef, 'ig-fm-verify-ff-')
+  assert.equal(rgit(clone, ['rev-parse', 'main']).trim(), c2, 'upstream main fast-forwarded to C2')
+  // history intact: both commits, in order
+  assert.equal(rgit(clone, ['log', '--format=%s', 'main']).trim(), 'bob: add a line\nfirst commit')
+  // byte-identical: C2 present with Bob's authorship
+  assert.equal(rgit(clone, ['cat-file', '-t', c2]).trim(), 'commit')
+  assert.match(rgit(clone, ['cat-file', 'commit', c2]), /author Bob Contributor <bob@example\.com>/)
+  assert.equal(rgit(clone, ['show', `${c2}:readme.md`]), 'hello world\nbob was here\n')
+
+  // provenance: the owner-copy of C2 carries copied_from → Bob's fork object
+  const copy = JSON.parse(ig(tmpdir(), ['get', `${ownerPk}.${uuidv5ObjSync(upstreamRef, c2)}`, '--identity', 'default']))
+  assert.equal(copy.item.pubkey, ownerPk, 'C2 copy is owner-signed')
+  assert.equal(copy.item.relations.copied_from[0].ref, `${bobPk}.${uuidv5ObjSync(forkRef, c2)}`)
+})
+
+test('--no-ff merge: creates an owner merge commit whose parents include C2', () => {
+  const { ref: upstreamRef, c1 } = seedUpstream()
+  const { forkRef, c2 } = contributorFork(upstreamRef)
+
+  const ownerWork = ownerCloneUpstream(upstreamRef)
+  setActiveIdentity(store, 'default')
+  const out = ig(ownerWork, ['git', 'merge', forkRef, 'feature', '--no-ff', '--identity', 'default', '--message', 'Merge feature']).trim()
+  const mergeTip = out.split('\n').pop().trim()
+
+  const clone = verifyClone(upstreamRef, 'ig-fm-verify-noff-')
+  assert.equal(rgit(clone, ['rev-parse', 'main']).trim(), mergeTip)
+  // merge commit has two parents: C1 and C2
+  const parents = rgit(clone, ['rev-list', '--parents', '-n', '1', mergeTip]).trim().split(/\s+/).slice(1)
+  assert.deepEqual(parents.sort(), [c1, c2].sort(), 'merge commit parents are C1 and C2')
+  // Bob's commit is present byte-identically inside the merged history
+  assert.match(rgit(clone, ['cat-file', 'commit', c2]), /author Bob Contributor/)
+  assert.equal(rgit(clone, ['show', `${c2}:readme.md`]), 'hello world\nbob was here\n')
+})
+
+// ── inline uuid_v5("obj:"+oid) so tests can address stored objects ──
+function uuidv5ObjSync(repoRef, oid) {
+  const repoId = repoRef.split('.').slice(1).join('.')
+  const nsHex = repoId.replace(/-/g, '')
+  const ns = Buffer.from(nsHex, 'hex')
+  const name = Buffer.from('obj:' + oid, 'utf-8')
+  const h = createHash('sha1').update(Buffer.concat([ns, name])).digest()
+  const b = h.subarray(0, 16)
+  b[6] = (b[6] & 0x0f) | 0x50
+  b[8] = (b[8] & 0x3f) | 0x80
+  const hex = b.toString('hex')
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20, 32)}`
+}

--- a/test/git-fork.test.js
+++ b/test/git-fork.test.js
@@ -9,7 +9,8 @@
 
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
-import { mkdtempSync, rmSync } from 'node:fs'
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -18,6 +19,7 @@ import { createFsStore } from '../src/store/fs.js'
 import { buildFixtureRepo } from '../test-support/git-fixture.js'
 import { throwawayIdentity } from '../test-support/throwaway-identity.js'
 import { initRepo, openRepo, forkRepo } from '../src/git/repo.js'
+import { pushToRemote } from '../src/git/transfer.js'
 import { objRef } from '../src/git/addressing.js'
 
 async function twoParty() {
@@ -103,6 +105,62 @@ test('fork prefers its own object over the upstream copy at the same oid', async
   assert.ok(localAddr.startsWith(bobClient.pubkey + '.'))
   assert.ok((await bobClient.get(localAddr)).item, 'fork stored its own copy')
 
+  rmSync(dataDir, { recursive: true, force: true })
+})
+
+test('fork delta relations resolve across the graft point (no dangling sugar)', async () => {
+  // Generic graph-walkers (the web viewer) follow `relations`; on a thin fork a
+  // delta object's parent/tree/entry must point at the namespace where the
+  // referenced object actually lives — fork-local for the delta, upstream for
+  // objects it inherited — not blindly at the fork namespace.
+  const { dataDir, aliceClient, bobClient } = await twoParty()
+  const up = mkdtempSync(join(tmpdir(), 'ig-fork-rel-'))
+  const G = {
+    ...process.env, GIT_CONFIG_GLOBAL: '/dev/null', GIT_CONFIG_SYSTEM: '/dev/null',
+    GIT_AUTHOR_NAME: 'A', GIT_AUTHOR_EMAIL: 'a@e', GIT_AUTHOR_DATE: '1700000000 +0000',
+    GIT_COMMITTER_NAME: 'A', GIT_COMMITTER_EMAIL: 'a@e', GIT_COMMITTER_DATE: '1700000000 +0000',
+  }
+  const g = (args) => execFileSync('git', ['-C', up, ...args], { env: G }).toString('utf-8')
+  g(['init', '-q', '-b', 'main'])
+  writeFileSync(join(up, 'a.txt'), 'aaa\n'); writeFileSync(join(up, 'b.txt'), 'bbb\n')
+  g(['add', '-A']); g(['commit', '-q', '-m', 'c1'])
+
+  const upstreamRef = await initRepo({ client: aliceClient, id: crypto.randomUUID(), name: 'up', in: ['server-public'], defaultBranch: 'refs/heads/main' })
+  const upstream = await openRepo({ client: aliceClient, repoRef: upstreamRef })
+  await pushToRemote({ repo: upstream, gitDir: join(up, '.git'), pushes: [{ src: 'refs/heads/main', dst: 'refs/heads/main', force: false }] })
+
+  const { ref: forkRef } = await forkRepo({ client: bobClient, upstreamRef })
+  const fork = await openRepo({ client: bobClient, repoRef: forkRef })
+
+  // change ONLY a.txt → new commit + new root tree + new a.txt blob; b.txt's
+  // blob is inherited (lives upstream, not in the fork).
+  g(['checkout', '-q', '-b', 'feature'])
+  writeFileSync(join(up, 'a.txt'), 'aaa2\n'); g(['add', '-A']); g(['commit', '-q', '-m', 'c2'])
+  const c2 = g(['rev-parse', 'HEAD']).trim()
+  await pushToRemote({ repo: fork, gitDir: join(up, '.git'), pushes: [{ src: 'refs/heads/feature', dst: 'refs/heads/feature', force: false }] })
+
+  const c2obj = (await bobClient.get(await objRef(fork.owner, fork.repoId, c2))).item
+
+  // parent → the upstream namespace, and it resolves (would be a 404 in the fork ns)
+  const parentRef = c2obj.relations.parent[0].ref
+  assert.ok((await bobClient.get(parentRef))?.item, 'parent relation must resolve')
+  assert.ok(parentRef.startsWith(aliceClient.pubkey + '.'), 'parent points at the upstream owner namespace')
+
+  // tree → the new (fork-local) root tree, resolves
+  const treeRef = c2obj.relations.tree[0].ref
+  assert.ok(treeRef.startsWith(bobClient.pubkey + '.'), 'new root tree is fork-local')
+  const treeObj = (await bobClient.get(treeRef)).item
+
+  // every entry resolves: a.txt (changed → fork-local), b.txt (unchanged → upstream)
+  for (const e of treeObj.relations.entry) {
+    const owner = e.ref.startsWith(bobClient.pubkey + '.') ? 'fork' : 'upstream'
+    assert.ok((await bobClient.get(e.ref))?.item, `entry ${e.name} (${owner}) must resolve`)
+  }
+  const byName = Object.fromEntries(treeObj.relations.entry.map(e => [e.name, e.ref]))
+  assert.ok(byName['a.txt'].startsWith(bobClient.pubkey + '.'), 'changed blob is fork-local')
+  assert.ok(byName['b.txt'].startsWith(aliceClient.pubkey + '.'), 'inherited blob points upstream')
+
+  rmSync(up, { recursive: true, force: true })
   rmSync(dataDir, { recursive: true, force: true })
 })
 

--- a/test/git-fork.test.js
+++ b/test/git-fork.test.js
@@ -1,0 +1,125 @@
+/**
+ * Thin forks: an O(1) fork anchor (forked_from + one mirrored ref, zero git
+ * objects) and the resolver fallthrough that lets a fork read upstream objects
+ * by computing their address in the upstream owner's namespace on a local miss.
+ *
+ * Two identities over one fs store (Alice = upstream owner, Bob = contributor),
+ * mirroring the single-owner-push model.
+ */
+
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { createClient } from '../src/client.js'
+import { createFsStore } from '../src/store/fs.js'
+import { buildFixtureRepo } from '../test-support/git-fixture.js'
+import { throwawayIdentity } from '../test-support/throwaway-identity.js'
+import { initRepo, openRepo, forkRepo } from '../src/git/repo.js'
+import { objRef } from '../src/git/addressing.js'
+
+async function twoParty() {
+  const dataDir = mkdtempSync(join(tmpdir(), 'ig-fork-'))
+  const store = createFsStore({ dataDir, filter: null })
+  const alice = await throwawayIdentity()
+  const bob = await throwawayIdentity()
+  const aliceClient = createClient({ store, identity: alice.identity }); await aliceClient.ready
+  const bobClient = createClient({ store, identity: bob.identity }); await bobClient.ready
+  return { dataDir, store, alice, bob, aliceClient, bobClient }
+}
+
+/** Alice: a repo carrying the whole fixture history with main → its head. */
+async function upstreamWithFixture(aliceClient) {
+  const fx = buildFixtureRepo()
+  const repoRef = await initRepo({ client: aliceClient, id: crypto.randomUUID(), name: 'upstream', in: ['server-public'], defaultBranch: 'refs/heads/main' })
+  const repo = await openRepo({ client: aliceClient, repoRef })
+  for (const o of fx.objects) await repo.putObject(o.type, o.payload)
+  await repo.putRef('refs/heads/main', { targetOid: fx.head }, { expectedOldOid: null })
+  return { fx, repoRef, repo }
+}
+
+test('forkRepo: O(1) anchor with forked_from + one mirrored ref, zero git objects', async () => {
+  const { dataDir, aliceClient, bobClient } = await twoParty()
+  const { fx, repoRef: upstreamRef } = await upstreamWithFixture(aliceClient)
+
+  const { ref: forkRef } = await forkRepo({ client: bobClient, upstreamRef, name: 'my-fork' })
+  assert.ok(forkRef.startsWith((await bobClient.pubkey) + '.') || forkRef.startsWith(bobClient.pubkey + '.'))
+
+  const anchor = (await bobClient.get(forkRef)).item
+  assert.equal(anchor.content.name, 'my-fork')
+  assert.deepEqual(anchor.relations.forked_from.map(r => r.ref), [upstreamRef], 'forked_from → upstream')
+  assert.deepEqual(anchor.in, ['server-public'], 'fork inherits upstream realm by default')
+
+  const fork = await openRepo({ client: bobClient, repoRef: forkRef })
+  assert.deepEqual(fork.forkedFrom, [upstreamRef])
+
+  // the mirrored default branch points at the upstream tip …
+  const main = await fork.getRef('refs/heads/main')
+  assert.equal(main.targetOid, fx.head, 'mirrored main → upstream tip')
+
+  // … and NOT a single git object was copied into the fork namespace (thin fork).
+  assert.equal(await fork.hasObjectLocal(fx.head), false, 'no git objects stored in the fork')
+  assert.equal(await fork.getObjectLocal(fx.head), null)
+
+  rmSync(dataDir, { recursive: true, force: true })
+})
+
+test('resolver fallthrough: fork.getObject resolves upstream objects it does not store', async () => {
+  const { dataDir, aliceClient, bobClient } = await twoParty()
+  const { fx, repoRef: upstreamRef } = await upstreamWithFixture(aliceClient)
+  const { ref: forkRef } = await forkRepo({ client: bobClient, upstreamRef })
+  const fork = await openRepo({ client: bobClient, repoRef: forkRef })
+
+  // every reachable upstream object resolves through the fork, byte-identically
+  for (const o of fx.objects) {
+    const got = await fork.getObject(o.oid)
+    assert.ok(got, `fork must resolve upstream object ${o.type} ${o.oid}`)
+    assert.equal(got.otype, o.type)
+    assert.deepEqual(Buffer.from(got.payload), o.payload)
+  }
+  assert.equal(await fork.hasObject(fx.head), true, 'hasObject also falls through')
+  // a genuinely-absent object is still null (no infinite walk)
+  assert.equal(await fork.getObject('0'.repeat(40)), null)
+
+  rmSync(dataDir, { recursive: true, force: true })
+})
+
+test('fork prefers its own object over the upstream copy at the same oid', async () => {
+  // A blob present in BOTH namespaces must resolve from the fork's own copy.
+  const { dataDir, aliceClient, bobClient } = await twoParty()
+  const { repoRef: upstreamRef } = await upstreamWithFixture(aliceClient)
+  const { ref: forkRef } = await forkRepo({ client: bobClient, upstreamRef })
+  const fork = await openRepo({ client: bobClient, repoRef: forkRef })
+
+  const payload = Buffer.from('hello world\n') // same as a fixture blob
+  const oid = await fork.putObject('blob', payload)
+  const localAddr = await objRef(fork.owner, fork.repoId, oid)
+  const got = await fork.getObject(oid)
+  assert.ok(got)
+  assert.deepEqual(Buffer.from(got.payload), payload)
+  // it came from the fork's namespace (owner = Bob), not Alice's
+  assert.ok(localAddr.startsWith(bobClient.pubkey + '.'))
+  assert.ok((await bobClient.get(localAddr)).item, 'fork stored its own copy')
+
+  rmSync(dataDir, { recursive: true, force: true })
+})
+
+test('putObject extraRelations: copied_from / merges land on the written object', async () => {
+  const { dataDir, aliceClient } = await twoParty()
+  const repoRef = await initRepo({ client: aliceClient, id: crypto.randomUUID(), name: 'prov', in: ['server-public'] })
+  const repo = await openRepo({ client: aliceClient, repoRef })
+
+  const src = `${aliceClient.pubkey}.11111111-1111-4111-8111-111111111111`
+  const mr = `${aliceClient.pubkey}.22222222-2222-4222-8222-222222222222`
+  const oid = await repo.putObject('blob', Buffer.from('contrib\n'), {
+    extraRelations: { copied_from: [{ ref: src }], merges: [{ ref: mr }] },
+  })
+  const obj = (await aliceClient.get(await objRef(repo.owner, repo.repoId, oid))).item
+  assert.deepEqual(obj.relations.copied_from.map(r => r.ref), [src])
+  assert.deepEqual(obj.relations.merges.map(r => r.ref), [mr])
+  assert.equal(obj.relations.type_def[0].ref !== undefined, true, 'base relations preserved')
+
+  rmSync(dataDir, { recursive: true, force: true })
+})

--- a/test/git-merge.test.js
+++ b/test/git-merge.test.js
@@ -1,0 +1,139 @@
+/**
+ * merge internals (src/git/merge.js) at the API level, over a real local git
+ * repo + an fs-backed ig store with two identities. Covers the parts the CLI
+ * e2e does not: the owner-only guard, --ff-only rejection on divergence, and
+ * the provenance placement of `copied_from` / `merges` (native-mode form b).
+ */
+
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { createClient } from '../src/client.js'
+import { createFsStore } from '../src/store/fs.js'
+import { throwawayIdentity } from '../test-support/throwaway-identity.js'
+import { parseRef } from '../src/object.js'
+import { initRepo, openRepo, forkRepo } from '../src/git/repo.js'
+import { pushToRemote } from '../src/git/transfer.js'
+import { objRef } from '../src/git/addressing.js'
+import { mergeIntoUpstream } from '../src/git/merge.js'
+
+const FIXED = {
+  GIT_CONFIG_GLOBAL: '/dev/null', GIT_CONFIG_SYSTEM: '/dev/null',
+  GIT_AUTHOR_NAME: 'Bob', GIT_AUTHOR_EMAIL: 'bob@example.com', GIT_AUTHOR_DATE: '1700001000 +0000',
+  GIT_COMMITTER_NAME: 'Bob', GIT_COMMITTER_EMAIL: 'bob@example.com', GIT_COMMITTER_DATE: '1700001000 +0000',
+}
+const sh = (dir, args, extra = {}) =>
+  execFileSync('git', ['-C', dir, ...args], { env: { ...process.env, ...FIXED, ...extra }, maxBuffer: 1 << 26 }).toString('utf-8')
+const mkd = (p) => mkdtempSync(join(tmpdir(), p))
+
+/**
+ * Build: a local git repo (main=C1, feature=C2), alice's upstream (main→C1),
+ * bob's thin fork (feature→C2, delta-only), and an owner working copy checked
+ * out on main at C1 with a committer identity configured.
+ */
+async function scenario() {
+  const dataDir = mkd('ig-merge-store-')
+  const store = createFsStore({ dataDir, filter: null })
+  const alice = await throwawayIdentity(); const bob = await throwawayIdentity()
+  const aliceClient = createClient({ store, identity: alice.identity }); await aliceClient.ready
+  const bobClient = createClient({ store, identity: bob.identity }); await bobClient.ready
+
+  const up = mkd('ig-merge-up-')
+  sh(up, ['init', '-q', '-b', 'main'])
+  writeFileSync(join(up, 'readme.md'), 'hello\n'); sh(up, ['add', '-A']); sh(up, ['commit', '-q', '-m', 'c1'])
+  const c1 = sh(up, ['rev-parse', 'HEAD']).trim()
+  sh(up, ['checkout', '-q', '-b', 'feature'])
+  writeFileSync(join(up, 'readme.md'), 'hello\nmore\n'); sh(up, ['add', '-A']); sh(up, ['commit', '-q', '-m', 'c2'])
+  const c2 = sh(up, ['rev-parse', 'HEAD']).trim()
+  const upGitDir = join(up, '.git')
+
+  const upstreamRef = await initRepo({ client: aliceClient, id: crypto.randomUUID(), name: 'up', in: ['server-public'], defaultBranch: 'refs/heads/main' })
+  const upstream = await openRepo({ client: aliceClient, repoRef: upstreamRef })
+  await pushToRemote({ repo: upstream, gitDir: upGitDir, pushes: [{ src: 'refs/heads/main', dst: 'refs/heads/main', force: false }] })
+
+  const { ref: forkRef } = await forkRepo({ client: bobClient, upstreamRef })
+  const fork = await openRepo({ client: bobClient, repoRef: forkRef })
+  await pushToRemote({ repo: fork, gitDir: upGitDir, pushes: [{ src: 'refs/heads/feature', dst: 'refs/heads/feature', force: false }] })
+
+  const ownerWork = mkd('ig-merge-owner-'); rmSync(ownerWork, { recursive: true, force: true })
+  execFileSync('git', ['clone', '--quiet', '--single-branch', '--branch', 'main', up, ownerWork],
+    { env: { ...process.env, GIT_CONFIG_GLOBAL: '/dev/null', GIT_CONFIG_SYSTEM: '/dev/null' }, maxBuffer: 1 << 26 })
+  sh(ownerWork, ['config', 'user.name', 'Owner']); sh(ownerWork, ['config', 'user.email', 'owner@example.com'])
+
+  return { dataDir, up, store, alice, bob, aliceClient, bobClient, upstreamRef, forkRef, ownerWork, ownerGitDir: join(ownerWork, '.git'), c1, c2 }
+}
+
+const cleanup = (s) => { for (const d of [s.dataDir, s.up, s.ownerWork]) try { rmSync(d, { recursive: true, force: true }) } catch {} }
+
+test('merge is refused for anyone but the upstream owner', async () => {
+  const s = await scenario()
+  await assert.rejects(
+    () => mergeIntoUpstream({ client: s.bobClient, gitDir: s.ownerGitDir, worktree: s.ownerWork, sourceRef: s.forkRef, sourceBranch: 'feature' }),
+    /only the owner can merge/i
+  )
+  cleanup(s)
+})
+
+test('fast-forward merge: head copy carries copied_from AND merges (native mode)', async () => {
+  const s = await scenario()
+  const mrRef = `${s.bob.pubkey}.abcdef01-2345-4678-8abc-def012345678`
+  const res = await mergeIntoUpstream({
+    client: s.aliceClient, gitDir: s.ownerGitDir, worktree: s.ownerWork,
+    sourceRef: s.forkRef, sourceBranch: 'feature', mergeRequestRef: mrRef,
+  })
+  assert.equal(res.kind, 'fast-forward')
+  assert.equal(res.newTip, s.c2)
+
+  const { pubkey: upOwner, id: upId } = parseRef(s.upstreamRef)
+  const headCopy = (await s.aliceClient.get(await objRef(upOwner, upId, s.c2))).item
+  assert.equal(headCopy.pubkey, upOwner, 'C2 copy is owner-signed')
+  assert.deepEqual(headCopy.relations.merges.map(r => r.ref), [mrRef], 'head records merges → MR')
+  const { pubkey: fkOwner, id: fkId } = parseRef(s.forkRef)
+  assert.deepEqual(headCopy.relations.copied_from.map(r => r.ref), [await objRef(fkOwner, fkId, s.c2)])
+
+  // upstream main advanced to C2 via CAS
+  assert.equal((await openRepo({ client: s.aliceClient, repoRef: s.upstreamRef }).then(r => r.getRef('refs/heads/main'))).targetOid, s.c2)
+  cleanup(s)
+})
+
+test('--ff-only refuses a diverged branch; --no-ff then makes a merge commit', async () => {
+  const s = await scenario()
+  // owner advances main to C3 (a sibling of C2 off C1) and publishes it
+  writeFileSync(join(s.ownerWork, 'owner.txt'), 'owner change\n')
+  sh(s.ownerWork, ['add', '-A']); sh(s.ownerWork, ['commit', '-q', '-m', 'c3'], { GIT_AUTHOR_NAME: 'Owner', GIT_AUTHOR_EMAIL: 'owner@example.com', GIT_COMMITTER_NAME: 'Owner', GIT_COMMITTER_EMAIL: 'owner@example.com' })
+  const c3 = sh(s.ownerWork, ['rev-parse', 'HEAD']).trim()
+  const upstream = await openRepo({ client: s.aliceClient, repoRef: s.upstreamRef })
+  await pushToRemote({ repo: upstream, gitDir: s.ownerGitDir, pushes: [{ src: 'refs/heads/main', dst: 'refs/heads/main', force: false }] })
+
+  // not a fast-forward → rejected under --ff-only
+  await assert.rejects(
+    () => mergeIntoUpstream({ client: s.aliceClient, gitDir: s.ownerGitDir, worktree: s.ownerWork, sourceRef: s.forkRef, sourceBranch: 'feature', mode: 'ff-only' }),
+    /not a fast-forward/i
+  )
+
+  // --no-ff builds a merge commit M with parents C3 and C2
+  const mrRef = `${s.bob.pubkey}.abcdef01-2345-4678-8abc-def012345678`
+  const res = await mergeIntoUpstream({
+    client: s.aliceClient, gitDir: s.ownerGitDir, worktree: s.ownerWork,
+    sourceRef: s.forkRef, sourceBranch: 'feature', mode: 'no-ff', message: 'merge feature', mergeRequestRef: mrRef,
+  })
+  assert.equal(res.kind, 'merge-commit')
+  const parents = sh(s.ownerWork, ['rev-list', '--parents', '-n', '1', res.newTip]).trim().split(/\s+/).slice(1)
+  assert.deepEqual(parents.sort(), [c3, s.c2].sort())
+
+  // the owner-created merge commit records `merges` but NOT `copied_from`
+  // (it has no fork original); C2 carries copied_from (it came from the fork).
+  const { pubkey: upOwner, id: upId } = parseRef(s.upstreamRef)
+  const mCopy = (await s.aliceClient.get(await objRef(upOwner, upId, res.newTip))).item
+  assert.deepEqual(mCopy.relations.merges.map(r => r.ref), [mrRef])
+  assert.equal(mCopy.relations.copied_from, undefined, 'merge commit has no copied_from')
+  const c2Copy = (await s.aliceClient.get(await objRef(upOwner, upId, s.c2))).item
+  const { pubkey: fkOwner, id: fkId } = parseRef(s.forkRef)
+  assert.deepEqual(c2Copy.relations.copied_from.map(r => r.ref), [await objRef(fkOwner, fkId, s.c2)])
+  assert.equal(c2Copy.relations.merges, undefined, 'non-head fork object has no merges')
+  cleanup(s)
+})

--- a/test/git-merge.test.js
+++ b/test/git-merge.test.js
@@ -137,3 +137,69 @@ test('--ff-only refuses a diverged branch; --no-ff then makes a merge commit', a
   assert.equal(c2Copy.relations.merges, undefined, 'non-head fork object has no merges')
   cleanup(s)
 })
+
+test('a conflicting --no-ff merge aborts cleanly and leaves the ref untouched', async () => {
+  const s = await scenario()
+  // owner rewrites the SAME line the fork touched, so a 3-way merge conflicts.
+  writeFileSync(join(s.ownerWork, 'readme.md'), 'hello\nowner-only\n')
+  sh(s.ownerWork, ['add', '-A']); sh(s.ownerWork, ['commit', '-q', '-m', 'c3 owner edit'],
+    { GIT_AUTHOR_NAME: 'Owner', GIT_AUTHOR_EMAIL: 'owner@example.com', GIT_COMMITTER_NAME: 'Owner', GIT_COMMITTER_EMAIL: 'owner@example.com' })
+  const c3 = sh(s.ownerWork, ['rev-parse', 'HEAD']).trim()
+  const upstream = await openRepo({ client: s.aliceClient, repoRef: s.upstreamRef })
+  await pushToRemote({ repo: upstream, gitDir: s.ownerGitDir, pushes: [{ src: 'refs/heads/main', dst: 'refs/heads/main', force: false }] })
+
+  await assert.rejects(
+    () => mergeIntoUpstream({ client: s.aliceClient, gitDir: s.ownerGitDir, worktree: s.ownerWork, sourceRef: s.forkRef, sourceBranch: 'feature', mode: 'no-ff' }),
+    /conflict/i
+  )
+  // abort worked: no MERGE_HEAD, working tree back at C3
+  assert.throws(() => sh(s.ownerWork, ['rev-parse', '--verify', '-q', 'MERGE_HEAD']), 'MERGE_HEAD cleared by --abort')
+  assert.equal(sh(s.ownerWork, ['rev-parse', 'HEAD']).trim(), c3)
+  // upstream ref never advanced
+  assert.equal((await upstream.getRef('refs/heads/main')).targetOid, c3, 'ref untouched after a failed merge')
+  cleanup(s)
+})
+
+test('re-merging an already-merged branch is a no-op (up-to-date)', async () => {
+  const s = await scenario()
+  const first = await mergeIntoUpstream({ client: s.aliceClient, gitDir: s.ownerGitDir, worktree: s.ownerWork, sourceRef: s.forkRef, sourceBranch: 'feature' })
+  assert.equal(first.newTip, s.c2)
+  const again = await mergeIntoUpstream({ client: s.aliceClient, gitDir: s.ownerGitDir, worktree: s.ownerWork, sourceRef: s.forkRef, sourceBranch: 'feature' })
+  assert.equal(again.kind, 'up-to-date')
+  assert.deepEqual(again.copied, [])
+  assert.equal(again.newTip, s.c2)
+  cleanup(s)
+})
+
+test('merge bootstraps content into an empty upstream (base === null)', async () => {
+  // upstream created but never pushed to (no refs); a fork carries the first commit.
+  const dataDir = mkd('ig-merge-empty-')
+  const store = createFsStore({ dataDir, filter: null })
+  const alice = await throwawayIdentity(); const bob = await throwawayIdentity()
+  const aliceClient = createClient({ store, identity: alice.identity }); await aliceClient.ready
+  const bobClient = createClient({ store, identity: bob.identity }); await bobClient.ready
+
+  const upstreamRef = await initRepo({ client: aliceClient, id: crypto.randomUUID(), name: 'empty', in: ['server-public'], defaultBranch: 'refs/heads/main' })
+  const { ref: forkRef } = await forkRepo({ client: bobClient, upstreamRef })
+
+  // bob builds C1 locally and pushes it to the fork's main
+  const up = mkd('ig-merge-empty-up-')
+  sh(up, ['init', '-q', '-b', 'main'])
+  writeFileSync(join(up, 'readme.md'), 'first\n'); sh(up, ['add', '-A']); sh(up, ['commit', '-q', '-m', 'c1'])
+  const c1 = sh(up, ['rev-parse', 'HEAD']).trim()
+  const fork = await openRepo({ client: bobClient, repoRef: forkRef })
+  await pushToRemote({ repo: fork, gitDir: join(up, '.git'), pushes: [{ src: 'refs/heads/main', dst: 'refs/heads/main', force: false }] })
+
+  // owner has an empty (unborn-HEAD) checkout of the still-empty upstream
+  const ownerWork = mkd('ig-merge-empty-owner-')
+  sh(ownerWork, ['init', '-q', '-b', 'main'])
+  sh(ownerWork, ['config', 'user.name', 'Owner']); sh(ownerWork, ['config', 'user.email', 'owner@example.com'])
+
+  const res = await mergeIntoUpstream({ client: aliceClient, gitDir: join(ownerWork, '.git'), worktree: ownerWork, sourceRef: forkRef, sourceBranch: 'main' })
+  assert.equal(res.base, null)
+  assert.equal(res.newTip, c1)
+  const upstream = await openRepo({ client: aliceClient, repoRef: upstreamRef })
+  assert.equal((await upstream.getRef('refs/heads/main')).targetOid, c1, 'empty upstream main created at C1')
+
+  for (const d of [dataDir, up, ownerWork]) try { rmSync(d, { recursive: true, force: true }) } catch {}
+})


### PR DESCRIPTION
Stacked on #15 (base = `feat/git-remote-ig`, **not** `main`). Implements the fork + merge collaboration flow from the [Q5 MERGE_REQUEST-flow memo](../specs/20260712-git-on-instructiongraph/open-question-5-merge-request-flow.md). Merge #15 first, then retarget this to `main`.

## What it adds
- **`ig git fork <upstream> [--name N] [--realm R]`** — O(1) thin fork: a new `GIT_REPOSITORY` anchor with `forked_from → upstream` + one mirrored default-branch `GIT_REF` (target = upstream tip). **Zero `GIT_OBJECT`s copied.**
- **Resolver fallthrough** — `openRepo().getObject/hasObject` walk the `forked_from` chain on a local miss, computing `uuid_v5(upstream_repo_id,"obj:"+oid)` in each upstream owner's namespace (depth-first, cycle-guarded, lazy). Namespace-only variants exposed as `getObjectLocal/hasObjectLocal`. Because Phase 1's push already sends the delta, this is all a thin-fork *clone* needs.
- **`ig git merge <fork> [branch] [--into U] [--onto R] [--ff-only|--no-ff]`** — owner-side, client-computed (the hub never merges). Fetches the fork delta (re-verifying every oid), runs plain local `git merge` (ff or merge-commit), signs owner-copies into the upstream namespace — each with `copied_from → the contributor's original` — and CAS-updates the ref. `--into` defaults to the fork's `forked_from`; `--onto` to its default branch.

## Provenance (memo §3, Option A)
Git authorship rides inside the commit payload byte-for-byte (identical oid), so the owner's envelope signature on a copy is *hosting attestation*, not authorship — exactly what any git server does. `copied_from` is set only where the fork actually stores the object, so it never dangles onto owner-authored merge objects; `merges → MR` lands on the head/merge commit only in native-mode (form b).

## Testing — 267 green (+12 over the 255 baseline)
- **Full-loop e2e through real git across two identities** (`test/git-fork-merge-e2e.test.js`): init upstream → clone → fork → commit → push (thin: fork stores only its delta, not the base) → merge → fresh clone: `git fsck` clean, history intact, contributor commit **byte-identical** with its authorship, owner-copy carries `copied_from`. Both fast-forward and `--no-ff` (merge commit, parents C1+C2).
- **Unit**: resolver fallthrough + O(1) fork shape (`test/git-fork.test.js`); merge internals — owner-only guard, `--ff-only` rejection, conflict abort, up-to-date no-op, empty-upstream bootstrap, provenance placement (`test/git-merge.test.js`).

## Review
Two independent adversarial reviews (codex + code-reviewer) before opening. Real findings fixed (fork flag-order parse, missing ff-path error handling, three test-coverage gaps); false positives recorded in commit `3466d5b`. Design decisions and known limitations (dangling relation *sugar*; multi-level-fork `copied_from` attribution; shared-realm write-side open question) are written up in [`notes/deviations.md`](notes/deviations.md).

## Not in this PR (deferred, needs owner sign-off)
Merge **form (b)** — a `MERGE_REQUEST` ref as merge source — is plumbed (`mergeIntoUpstream({ mergeRequestRef })` sets `merges → MR`, tested) but not CLI-exposed: it needs the AgentFlow-owned `MERGE_REQUEST` type extended additively (`source_repository`/`target_repository`, `base_oid`/`head_oid`). That type re-sign is gated on owner approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)