### PR TITLE
feat(freenet): Freenet backend for ig — publish, read, and verify the inbound-relations index

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,11 @@ Notes and limits:
 - **The contract WASMs are pinned artifacts, never rebuilt on the fly.** Their
   bytes define the keyspace: a rebuilt contract addresses a different, empty
   universe, and every existing object then reads as unpublished rather than as
-  an error. Hence a configured directory rather than a build step.
+  an error. Hence a configured directory rather than a build step. The
+  canonical source of the pinned builds is `artifacts/` in
+  [`tijszwinkels/dataverse-freenet`](https://github.com/tijszwinkels/dataverse-freenet);
+  point `freenet-contracts-dir` at a checkout of it. There is deliberately no
+  default — any default would be a machine-specific path into another repo.
 - `ig freenet get --rev N` never falls back to the head. The absence of a
   revision is meaningful; answering with a different revision would be worse
   than answering nothing.

--- a/README.md
+++ b/README.md
@@ -99,6 +99,11 @@ ig realm set dataverse001        # Public realm
 ig realm set identity            # Private realm
 ig realm set <realm>             # Custom realm
 ig git init [name] [--realm R]   # Create a git repository (prints its ref)
+ig freenet publish <ref>         # Publish to Freenet, poke targets' indexes
+ig freenet get <ref> [--rev N]   # Read a head, or one immutable revision
+ig freenet inbound <ref>         # Who points at this object (index slot map)
+ig freenet verify <ref>          # Check index slots against their snapshots
+ig freenet derive <ref>          # Print derived contract ids (contacts nothing)
 ```
 
 ## Git hosting (`git clone ig::…`)
@@ -154,6 +159,76 @@ works offline too.
   incomplete). Fetch trusts the local object store's connectivity, exactly as
   git's own transports do.
 
+## Freenet backend (`ig freenet`)
+
+Publish signed objects to [Freenet](https://freenet.org) and read them back,
+including an **inbound-relations index** — the answer to "who points at this
+object?", stored on the network rather than in a server-side database.
+
+Every contract is addressed from the object's ref alone, so there is no index
+to consult and nothing to look up:
+
+| contract | holds | address |
+|---|---|---|
+| head | the current envelope | `params32`, mutable, last-writer-wins on revision |
+| snapshot | one immutable revision | `params40`, one contract per `(ref, revision)` |
+| index | who points at this object | `params32` **of the target** |
+
+```
+params32    = BLAKE3(pubkey_raw_33B)[..16] ‖ uuid_16B
+params40    = params32 ‖ revision_be64
+contract_id = base58( BLAKE3( BLAKE3(wasm_bytes) ‖ params ) )
+```
+
+The contract WASM hashes into the id, which is what keeps the three keyspaces
+apart even though all three are derived from the same ref.
+
+```bash
+# One-time setup: the node's port and the pinned contract WASMs.
+ig freenet config freenet-contracts-dir /path/to/contracts
+ig freenet config freenet-port 7509
+
+ig freenet publish <ref>          # or a path to a signed envelope JSON
+ig freenet inbound <ref> | jq .   # {"<source-ref>": {"revision": 3, "relations": ["root"]}}
+ig freenet verify <ref>           # exit 0 iff every slot verifies
+ig freenet derive <ref> --rev 3   # debug addressing without touching the node
+```
+
+`publish` runs an ordered flow: snapshot PUT → a **GET-back gate** → head PUT →
+one poke per distinct target in `item.relations`. The gate matters: a poke makes
+the target's index fetch the source's snapshot, so poking before that snapshot
+is confirmed stalls every poke for the node's multi-minute fetch budget and then
+fails. If the snapshot is not confirmed, nothing is poked at all.
+
+Everything is idempotent — the snapshot re-PUT is a no-op, the head merge is
+LWW, and pokes are LWW — so a partial run is fixed by running it again. Pokes
+are independent; `publish` reports each target and exits non-zero if any failed.
+
+Notes and limits:
+
+- **The contract WASMs are pinned artifacts, never rebuilt on the fly.** Their
+  bytes define the keyspace: a rebuilt contract addresses a different, empty
+  universe, and every existing object then reads as unpublished rather than as
+  an error. Hence a configured directory rather than a build step.
+- `ig freenet get --rev N` never falls back to the head. The absence of a
+  revision is meaningful; answering with a different revision would be worse
+  than answering nothing.
+- `inbound` distinguishes "no index exists" (exit 1 — nothing has ever poked
+  this target) from "an index with no slots" (exit 0, `{}`).
+- **The index is a filter, not proof.** The contract's creation and seeding
+  paths accept structure-only states, so a slot is a claim until checked — that
+  is what `ig freenet verify` is for. It re-derives each slot from the source's
+  own signed snapshot and reports `verified-current`, `verified-stale` (the
+  source moved on, or its head is not on the node so currency is unknowable) or
+  `unverified`.
+- Node calls go through `fdev`, and every one is bounded (`--timeout`,
+  `--put-timeout`). An unbounded GET for a contract the node does not hold
+  blocks for minutes, which reads as a hung terminal.
+- BLAKE3 and base58 are vendored in `src/freenet/` rather than taken as
+  dependencies, so the package keeps zero runtime dependencies. They are
+  verified against the official BLAKE3 test vectors and against live contract
+  ids; signing itself is untouched and stays on Web Crypto.
+
 ## Architecture
 
 ```
@@ -169,9 +244,20 @@ src/
     hub.js          # createHubStore — HTTP hub backend
     fs.js           # createFsStore — filesystem (Node only)
     sync.js         # createSyncStore — local + remote sync
+  freenet/
+    blake3.js       # BLAKE3-256 (vendored; addressing only)
+    base58.js       # base58 encode/decode (vendored)
+    addressing.js   # ref → head / snapshot / index contract ids
+    contracts.js    # read + hash the pinned contract WASMs
+    config.js       # port, fdev path, contracts dir
+    fdev.js         # createFdevNode — bounded fdev subprocess client
+    relations.js    # one reading of an envelope's relations, shared
+    publish.js      # US-3.1 ordered publish + poke flow
+    verify.js       # US-3.4 slot verification
   index.js          # public re-exports
 cli/
   ig.js             # CLI entry point
+  freenet.js        # `ig freenet` command family
 ```
 
 ## Store Interface
@@ -229,6 +315,24 @@ const store = createSyncStore({ local: fsStore, remote: hubStore })
 ```bash
 node --test test/
 ```
+
+The Freenet end-to-end suite is skipped unless you opt in, since it needs the
+pinned contract WASMs and a node of your own:
+
+```bash
+export IG_FREENET_E2E_CONTRACTS=/path/to/contracts   # golden-id checks, offline
+
+freenet local --ws-api-address 127.0.0.1 --ws-api-port 7511 \
+  --config-dir ~/.cache/ig-freenet-e2e/config \
+  --data-dir   ~/.cache/ig-freenet-e2e/data
+export IG_FREENET_E2E_PORT=7511                      # + the live flow
+
+node --test test/freenet-e2e.test.js
+```
+
+Use a **local-mode node of your own**, never a shared or network node. Every
+other Freenet test runs offline against a fake `fdev`
+(`test-support/fake-fdev.js`).
 
 ## Cross-compatibility
 

--- a/cli/freenet.js
+++ b/cli/freenet.js
@@ -251,12 +251,18 @@ async function cmdPublish(positional, flags) {
       ? `   ✓ ${poke.target}${poke.created ? '  (index created)' : ''}`
       : `   ✗ ${poke.target}  ${poke.error.split('\n').join(' ')}`)
   }
-  if (report.failed > 0) {
-    throw new Error(
-      `${report.failed} of ${report.pokes.length} poke(s) failed — re-run 'ig freenet publish ${ref}' to retry.\n` +
-      '  The flow is idempotent: the snapshot re-PUT is a no-op, the head merge is LWW, and pokes are LWW.',
-    )
-  }
+  if (report.ok) return
+
+  // Exit non-zero for EITHER failure mode. A green poke report over a head
+  // that never landed would tell the user their object is live when it isn't.
+  const reasons = []
+  if (!report.headState.confirmed) reasons.push(`the head was not confirmed — ${report.headState.detail}`)
+  if (report.failed > 0) reasons.push(`${report.failed} of ${report.pokes.length} poke(s) failed`)
+  throw new Error(
+    `${reasons.join('\n  ')}\n` +
+    `  Re-run 'ig freenet publish ${ref}' to retry — the flow is idempotent: the snapshot\n` +
+    '  re-PUT is a no-op, the head merge is LWW, and pokes are LWW.',
+  )
 }
 
 function cmdConfig(positional) {

--- a/cli/freenet.js
+++ b/cli/freenet.js
@@ -1,0 +1,312 @@
+/**
+ * `ig freenet` — publish and read dataverse objects on Freenet.
+ *
+ * Kept out of cli/ig.js (which only dispatches into it) because this family
+ * carries its own flag set, its own config keys and its own output contract.
+ *
+ * Output discipline, so the commands compose:
+ *   stdout  the payload only — envelope JSON, slot map, derived ids
+ *   stderr  progress, diagnostics, per-target reports
+ * Exit codes: 0 on success; 1 on failure, including a publish where any poke
+ * failed and a verify where any slot is unverified.
+ */
+
+import { readFileSync } from 'node:fs'
+import {
+  findConfigDir, readConfig, writeConfig, resolveIdentityConfig, openRuntime,
+} from './runtime.js'
+import { resolveFreenetConfig, FREENET_CONFIG_KEYS } from '../src/freenet/config.js'
+import { loadContracts } from '../src/freenet/contracts.js'
+import { createAddressing, parseRef } from '../src/freenet/addressing.js'
+import { createFdevNode } from '../src/freenet/fdev.js'
+import { publishObject } from '../src/freenet/publish.js'
+import { verifyIndex } from '../src/freenet/verify.js'
+
+const USAGE = `Usage: ig freenet <command> [options]
+
+Publish and read dataverse objects on Freenet, including the inbound-relations
+index. Every object is addressed from its ref alone:
+
+  head      the current envelope         mutable, last-writer-wins on revision
+  snapshot  one immutable revision       one contract per (ref, revision)
+  index     who points at this object    keyed on the TARGET's params
+
+Commands:
+  ig freenet publish <ref>          Publish an object and poke its targets' indexes
+  ig freenet get <ref> [--rev N]    Fetch the head, or one immutable revision
+  ig freenet inbound <ref>          Print the inbound-relations slot map (JSON)
+  ig freenet verify <ref>           Verify each index slot against its snapshot
+  ig freenet derive <ref> [--rev N] Print derived contract ids; contacts nothing
+  ig freenet config [<key> <value>] Show or set Freenet configuration
+
+Publish performs the ordered flow: snapshot PUT, a GET-back gate, the head
+PUT, then one poke per distinct target in item.relations. It aborts before
+any poke if the snapshot is not confirmed, and exits non-zero if any poke
+failed. Everything is idempotent — re-run to converge.
+
+Options:
+  --rev N            Revision (get, derive). Absent means the head.
+  --port N           Node ws-api port (default 7509)
+  --fdev PATH        fdev binary (default: fdev on PATH)
+  --contracts-dir D  Directory holding the pinned contract WASMs
+  --timeout S        Read timeout in seconds (default 60)
+  --put-timeout S    Write timeout in seconds (default 330)
+  --identity N       Authenticate as identity N when resolving a private object
+  --json             Machine-readable output for publish/verify
+
+Configuration keys (ig freenet config <key> <value>):
+  ${FREENET_CONFIG_KEYS.port}          Node ws-api port
+  ${FREENET_CONFIG_KEYS.fdev}          Path to the fdev binary
+  ${FREENET_CONFIG_KEYS.contractsDir}  Directory of pinned contract WASMs
+
+The contracts directory must hold dataverse_object.wasm,
+dataverse_object_rev.wasm and dataverse_inbound_index.wasm. Those exact bytes
+define the keyspace — a rebuilt contract addresses a different, empty universe,
+so they are pinned artifacts, never rebuilt on the fly.`
+
+const BOOLEAN_FLAGS = ['json']
+const VALUE_FLAGS = ['rev', 'port', 'fdev', 'contracts-dir', 'timeout', 'put-timeout', 'identity']
+
+/** Parse argv into {positional, flags}; throws on anything unrecognised. */
+function parseArgs(argv, command) {
+  const flags = {}
+  const positional = []
+  for (let i = 0; i < argv.length; i++) {
+    const token = argv[i]
+    if (token === '--help' || token === '-h') {
+      flags.help = true
+      continue
+    }
+    if (!token.startsWith('-')) {
+      positional.push(token)
+      continue
+    }
+    const name = token.replace(/^--/, '')
+    if (BOOLEAN_FLAGS.includes(name)) {
+      flags[name] = true
+      continue
+    }
+    if (VALUE_FLAGS.includes(name)) {
+      const value = argv[++i]
+      if (value === undefined || value.startsWith('-')) {
+        throw new Error(`Option ${token} requires a value.\nRun 'ig freenet ${command} --help' for usage.`)
+      }
+      flags[name] = value
+      continue
+    }
+    throw new Error(`Unknown option for 'freenet ${command}': ${token}\nRun 'ig freenet --help' for usage.`)
+  }
+  return { positional, flags }
+}
+
+/** A non-negative integer flag, or undefined. Rejects junk loudly. */
+function intFlag(flags, name) {
+  if (flags[name] === undefined) return undefined
+  const n = Number(flags[name])
+  if (!Number.isSafeInteger(n) || n < 0) {
+    throw new Error(`--${name} must be a non-negative integer, got: ${flags[name]}`)
+  }
+  return n
+}
+
+/** Wire up config → contracts → addressing → node for one invocation. */
+function openBackend(flags) {
+  const configDir = findConfigDir()
+  const config = resolveFreenetConfig(
+    (key) => readConfig(configDir, key, null),
+    {
+      port: flags.port === undefined ? undefined : intFlag(flags, 'port'),
+      fdev: flags.fdev,
+      contractsDir: flags['contracts-dir'],
+      timeout: flags.timeout === undefined ? undefined : intFlag(flags, 'timeout'),
+      putTimeout: flags['put-timeout'] === undefined ? undefined : intFlag(flags, 'put-timeout'),
+    },
+  )
+  const contracts = loadContracts(config.contractsDir)
+  return {
+    config,
+    contracts,
+    addressing: createAddressing(contracts.codeHashes),
+    node: createFdevNode({
+      fdevPath: config.fdevPath,
+      port: config.port,
+      timeoutMs: config.timeoutMs,
+      putTimeoutMs: config.putTimeoutMs,
+    }),
+  }
+}
+
+/**
+ * Resolve a signed envelope through the normal ig plumbing: local store first,
+ * hub if one is configured. A path to a JSON file also works, so an envelope
+ * that is not in any store can still be published.
+ */
+async function resolveEnvelope(ref, flags) {
+  if (ref.endsWith('.json')) {
+    try {
+      return JSON.parse(readFileSync(ref, 'utf-8'))
+    } catch (err) {
+      throw new Error(`Could not read envelope file ${ref}: ${err.message}`)
+    }
+  }
+  parseRef(ref)
+  const identityName = flags.identity
+  // Private and shared-realm objects need auth; only try it if we have a key.
+  const hasIdentity = !!identityName || !!resolveIdentityConfig(findConfigDir())
+  const ctx = await openRuntime({ identityName, authenticate: hasIdentity })
+  const envelope = await ctx.client.get(ref).catch(() => null)
+  if (!envelope) {
+    throw new Error(
+      `Not found in the local store or on the hub: ${ref}\n` +
+      '  Fetch or create it first (ig get / ig create), or pass a path to a signed envelope JSON file.',
+    )
+  }
+  return envelope
+}
+
+const log = (msg) => console.error(msg)
+
+// ─── commands ────────────────────────────────────────────────────
+
+async function cmdDerive(positional, flags) {
+  const [ref] = positional
+  if (!ref) throw new Error('Usage: ig freenet derive <ref> [--rev N]')
+  const { addressing } = openBackend(flags)
+  console.log(JSON.stringify(addressing.all(ref, intFlag(flags, 'rev')), null, 2))
+}
+
+async function cmdGet(positional, flags) {
+  const [ref] = positional
+  if (!ref) throw new Error('Usage: ig freenet get <ref> [--rev N]')
+  const { addressing, node } = openBackend(flags)
+  const rev = intFlag(flags, 'rev')
+
+  const id = rev === undefined ? addressing.headId(ref) : addressing.snapshotId(ref, rev)
+  const what = rev === undefined ? `head of ${ref}` : `${ref} at revision ${rev}`
+  log(`→ GET ${id}  (${what})`)
+
+  const res = await node.get(id)
+  if (!res.found) {
+    // No fallback from a missing revision to the head, ever: the absence of a
+    // revision is meaningful, and quietly answering with a different revision
+    // would be worse than answering nothing.
+    throw new Error(`Not found on the node: ${what}\n  contract ${id}\n  ${res.detail}`)
+  }
+  console.log(JSON.stringify(res.state, null, 2))
+}
+
+async function cmdInbound(positional, flags) {
+  const [ref] = positional
+  if (!ref) throw new Error('Usage: ig freenet inbound <ref>')
+  const { addressing, node } = openBackend(flags)
+  const id = addressing.indexId(ref)
+  log(`→ GET ${id}  (inbound index of ${ref})`)
+
+  const res = await node.get(id)
+  if (!res.found) {
+    throw new Error(
+      `No inbound index on the node for ${ref}\n  contract ${id}\n  ${res.detail}\n` +
+      '  No publish flow has poked this target yet — that is different from an index with no slots.',
+    )
+  }
+  console.log(JSON.stringify(res.state?.slots ?? {}, null, 2))
+}
+
+async function cmdVerify(positional, flags) {
+  const [ref] = positional
+  if (!ref) throw new Error('Usage: ig freenet verify <ref>')
+  const { addressing, node } = openBackend(flags)
+  const report = await verifyIndex({ ref, node, addressing, log })
+
+  if (flags.json) {
+    console.log(JSON.stringify(report, null, 2))
+  } else {
+    for (const slot of report.slots) {
+      console.log(
+        `${slot.status.padEnd(17)} ${slot.source} @ ${slot.slot?.revision}` +
+        (slot.detail ? `  (${slot.detail})` : ''),
+      )
+    }
+  }
+  log(`── ${report.slots.length} slot(s), ${report.unverified} unverified`)
+  if (!report.ok) {
+    throw new Error('Some slots could not be verified against their snapshots.')
+  }
+}
+
+async function cmdPublish(positional, flags) {
+  const [ref] = positional
+  if (!ref) throw new Error('Usage: ig freenet publish <ref>')
+  const envelope = await resolveEnvelope(ref, flags)
+  const { addressing, contracts, node, config } = openBackend(flags)
+
+  log(`══ publish on 127.0.0.1:${config.port}`)
+  const report = await publishObject({ envelope, node, addressing, contracts, log })
+
+  const ok = report.pokes.length - report.failed
+  if (flags.json) console.log(JSON.stringify(report, null, 2))
+  log(`══ per-target report (${ok}/${report.pokes.length} ok)`)
+  for (const poke of report.pokes) {
+    log(poke.ok
+      ? `   ✓ ${poke.target}${poke.created ? '  (index created)' : ''}`
+      : `   ✗ ${poke.target}  ${poke.error.split('\n').join(' ')}`)
+  }
+  if (report.failed > 0) {
+    throw new Error(
+      `${report.failed} of ${report.pokes.length} poke(s) failed — re-run 'ig freenet publish ${ref}' to retry.\n` +
+      '  The flow is idempotent: the snapshot re-PUT is a no-op, the head merge is LWW, and pokes are LWW.',
+    )
+  }
+}
+
+function cmdConfig(positional) {
+  const configDir = findConfigDir()
+  const keys = Object.values(FREENET_CONFIG_KEYS)
+
+  if (positional.length === 0) {
+    for (const key of keys) {
+      console.log(`${key.padEnd(24)} ${readConfig(configDir, key, '(unset)')}`)
+    }
+    return
+  }
+  const [key, value] = positional
+  if (!keys.includes(key)) {
+    throw new Error(`Unknown Freenet config key: ${key}\n  Known keys: ${keys.join(', ')}`)
+  }
+  if (value === undefined) {
+    console.log(readConfig(configDir, key, '(unset)'))
+    return
+  }
+  writeConfig(configDir, key, value)
+  console.error(`Set ${key} = ${value}`)
+}
+
+const COMMANDS = {
+  publish: cmdPublish,
+  get: cmdGet,
+  inbound: cmdInbound,
+  verify: cmdVerify,
+  derive: cmdDerive,
+  config: async (positional) => cmdConfig(positional),
+}
+
+/**
+ * @param {string[]} argv - args after `freenet`
+ */
+export async function runFreenet(argv) {
+  const sub = argv[0]
+  if (!sub || sub === '--help' || sub === '-h') {
+    console.log(USAGE)
+    return
+  }
+  if (!COMMANDS[sub]) {
+    throw new Error(`Unknown 'ig freenet' command: ${sub}\nRun 'ig freenet --help' for usage.`)
+  }
+
+  const { positional, flags } = parseArgs(argv.slice(1), sub)
+  if (flags.help) {
+    console.log(USAGE)
+    return
+  }
+  await COMMANDS[sub](positional, flags)
+}

--- a/cli/freenet.js
+++ b/cli/freenet.js
@@ -20,7 +20,7 @@ import { loadContracts } from '../src/freenet/contracts.js'
 import { createAddressing, parseRef } from '../src/freenet/addressing.js'
 import { createFdevNode } from '../src/freenet/fdev.js'
 import { publishObject } from '../src/freenet/publish.js'
-import { verifyIndex } from '../src/freenet/verify.js'
+import { verifyIndex, formatSlot } from '../src/freenet/verify.js'
 
 const USAGE = `Usage: ig freenet <command> [options]
 
@@ -216,18 +216,17 @@ async function cmdVerify(positional, flags) {
   const [ref] = positional
   if (!ref) throw new Error('Usage: ig freenet verify <ref>')
   const { addressing, node } = openBackend(flags)
-  const report = await verifyIndex({ ref, node, addressing, log })
 
-  if (flags.json) {
-    console.log(JSON.stringify(report, null, 2))
-  } else {
-    for (const slot of report.slots) {
-      console.log(
-        `${slot.status.padEnd(17)} ${slot.source} @ ${slot.slot?.revision}` +
-        (slot.detail ? `  (${slot.detail})` : ''),
-      )
-    }
-  }
+  // Each slot is printed exactly once, as it resolves. In human mode the
+  // slot lines ARE the payload, so they stream to stdout; under --json the
+  // payload is the report, so the same lines stream to stderr as progress.
+  const onSlot = flags.json
+    ? (slot) => log(formatSlot(slot))
+    : (slot) => console.log(formatSlot(slot))
+
+  const report = await verifyIndex({ ref, node, addressing, log, onSlot })
+  if (flags.json) console.log(JSON.stringify(report, null, 2))
+
   log(`── ${report.slots.length} slot(s), ${report.unverified} unverified`)
   if (!report.ok) {
     throw new Error('Some slots could not be verified against their snapshots.')

--- a/cli/ig.js
+++ b/cli/ig.js
@@ -139,6 +139,10 @@ Commands:
   ig git clone <ref> [dir]              Clone a hosted repo (names dir after it)
   ig git fork <upstream> [--name N]     Thin-fork a repo you can contribute to
   ig git merge <fork> [branch]          Merge a fork branch into upstream (owner)
+  ig freenet publish <ref>              Publish to Freenet; poke targets' indexes
+  ig freenet get <ref> [--rev N]        Read a head, or one immutable revision
+  ig freenet inbound <ref>              Inbound-relations index (who points here)
+  ig freenet verify <ref>               Verify index slots against their snapshots
 
 Run 'ig <command> --help' for command-specific help.`)
   process.exit(0)
@@ -765,7 +769,9 @@ const QUIET_COMMANDS = new Set(['identity', 'server', 'status', 'verify', 'get',
 
 async function main() {
   if (!cmd || cmd === '--help' || cmd === '-h') usage()
-  if (hasHelp()) commandUsage(cmd)
+  // `freenet` documents its own subcommands (and their flags) in cli/freenet.js,
+  // so it handles --help itself rather than through the flat docs map.
+  if (cmd !== 'freenet' && hasHelp()) commandUsage(cmd)
 
   switch (cmd) {
     case 'status': {
@@ -1180,6 +1186,13 @@ async function main() {
       } else {
         die('Usage: ig git [init [name] [--realm R] | clone <ref> [dir] | fork <upstream> | merge <fork> [branch]]')
       }
+      break
+    }
+
+    case 'freenet': {
+      // Own flag set, config keys and output contract — see cli/freenet.js.
+      const { runFreenet } = await import('./freenet.js')
+      await runFreenet(args.slice(1))
       break
     }
 

--- a/src/freenet/addressing.js
+++ b/src/freenet/addressing.js
@@ -72,6 +72,22 @@ function uuidBytes(uuid) {
 }
 
 /**
+ * A ref in the one form two refs must share to be "the same object".
+ *
+ * Addressing is uuid-case-insensitive (the uuid is hashed as bytes), so
+ * `…-000001` and `…-000001` in different cases reach the SAME contract. Any
+ * comparison of refs as strings has to agree with that, or a ref typed in
+ * uppercase would address the right index and then match none of its slots.
+ *
+ * @param {string} ref
+ * @returns {string}
+ */
+export function canonicalRef(ref) {
+  const { pubkey, uuid } = parseRef(ref)
+  return `${pubkey}.${uuid.toLowerCase()}`
+}
+
+/**
  * The object's 32-byte params — the address of a head or an inbound index.
  * @param {string} ref
  * @returns {Uint8Array} 32 bytes

--- a/src/freenet/addressing.js
+++ b/src/freenet/addressing.js
@@ -1,0 +1,158 @@
+/**
+ * Freenet contract addressing for dataverse objects.
+ *
+ * An object's ref (`<pubkey>.<uuid>`) determines, with no index and no
+ * lookup, the address of every contract that can hold something about it:
+ *
+ *   params32 = BLAKE3(pubkey_raw_33B)[..16] ‖ uuid_16B          (the object)
+ *   params40 = params32 ‖ revision_be64                          (one revision)
+ *   contract_id = base58( BLAKE3( BLAKE3(wasm) ‖ params ) )
+ *
+ * The WASM that hashes into the id is what separates the three keyspaces —
+ * all of them are addressed by the same ref:
+ *
+ *   head      dataverse_object.wasm        params32   mutable, LWW on revision
+ *   snapshot  dataverse_object_rev.wasm    params40   immutable, one per revision
+ *   index     dataverse_inbound_index.wasm params32   inbound relations, of the TARGET
+ *
+ * Note the index is keyed on its *target's* 32-byte params: "who points at
+ * me" is a property of me, so any reader who knows a ref can find its index.
+ *
+ * Pure and browser-safe — no I/O. Callers supply the code hashes (see
+ * contracts.js, which reads and hashes the pinned WASMs).
+ */
+
+import { blake3, blake3Concat } from './blake3.js'
+import { base58Encode } from './base58.js'
+import { base64urlDecode } from '../encoding.js'
+
+const UUID_RE = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/
+const PUBKEY_BYTES = 33 // compressed P-256 point
+const CODE_HASH_BYTES = 32
+
+/** Decode the pubkey half of a ref to its raw compressed bytes. */
+function decodePubkey(ref, pubkey) {
+  let raw
+  try {
+    raw = base64urlDecode(pubkey)
+  } catch {
+    throw new Error(`Invalid ref '${ref}': pubkey is not base64url`)
+  }
+  if (raw.length !== PUBKEY_BYTES) {
+    throw new Error(
+      `Invalid ref '${ref}': pubkey must decode to a ${PUBKEY_BYTES}-byte compressed public key (got ${raw.length})`,
+    )
+  }
+  return raw
+}
+
+/**
+ * Split and fully validate a dataverse ref.
+ * @param {string} ref - `<pubkey>.<uuid>`
+ * @returns {{pubkey: string, uuid: string}}
+ */
+export function parseRef(ref) {
+  if (typeof ref !== 'string' || !ref.includes('.')) {
+    throw new Error(`Invalid ref ${JSON.stringify(ref)}: expected <pubkey>.<uuid>`)
+  }
+  const dot = ref.indexOf('.')
+  const pubkey = ref.slice(0, dot)
+  const uuid = ref.slice(dot + 1)
+  if (!pubkey || !uuid) throw new Error(`Invalid ref '${ref}': expected <pubkey>.<uuid>`)
+  if (!UUID_RE.test(uuid)) throw new Error(`Invalid ref '${ref}': '${uuid}' is not a uuid`)
+  decodePubkey(ref, pubkey)
+  return { pubkey, uuid }
+}
+
+function uuidBytes(uuid) {
+  const hex = uuid.replace(/-/g, '')
+  const out = new Uint8Array(16)
+  for (let i = 0; i < 16; i++) out[i] = parseInt(hex.substr(i * 2, 2), 16)
+  return out
+}
+
+/**
+ * The object's 32-byte params — the address of a head or an inbound index.
+ * @param {string} ref
+ * @returns {Uint8Array} 32 bytes
+ */
+export function objectParams(ref) {
+  const { pubkey, uuid } = parseRef(ref)
+  const out = new Uint8Array(32)
+  // The 16-byte owner address: BLAKE3 of the raw compressed pubkey, truncated.
+  out.set(blake3(decodePubkey(ref, pubkey)).subarray(0, 16), 0)
+  out.set(uuidBytes(uuid), 16)
+  return out
+}
+
+/**
+ * The revision's 40-byte params — the address of one immutable snapshot.
+ * @param {string} ref
+ * @param {number} revision
+ * @returns {Uint8Array} 40 bytes
+ */
+export function snapshotParams(ref, revision) {
+  if (typeof revision !== 'number' || !Number.isSafeInteger(revision) || revision < 0) {
+    throw new Error(`Invalid revision ${JSON.stringify(revision)}: expected a non-negative integer`)
+  }
+  const out = new Uint8Array(40)
+  out.set(objectParams(ref), 0)
+  // Big-endian u64. Split at 2^32 so revisions above 4 billion still carry.
+  const hi = Math.floor(revision / 0x100000000)
+  const lo = revision >>> 0
+  for (let i = 0; i < 4; i++) {
+    out[32 + i] = (hi >>> ((3 - i) * 8)) & 0xff
+    out[36 + i] = (lo >>> ((3 - i) * 8)) & 0xff
+  }
+  return out
+}
+
+/**
+ * The base58 contract instance id Freenet addresses a contract by.
+ * @param {Uint8Array} codeHash - BLAKE3 of the contract WASM
+ * @param {Uint8Array} params
+ * @returns {string}
+ */
+export function contractId(codeHash, params) {
+  return base58Encode(blake3Concat(codeHash, params))
+}
+
+function requireCodeHash(hashes, key) {
+  const h = hashes?.[key]
+  if (!(h instanceof Uint8Array) || h.length !== CODE_HASH_BYTES) {
+    throw new Error(`Missing or malformed '${key}' code hash: expected ${CODE_HASH_BYTES} bytes`)
+  }
+  return h
+}
+
+/**
+ * Bind a set of contract code hashes and derive ids from refs alone.
+ *
+ * @param {{object: Uint8Array, snapshot: Uint8Array, index: Uint8Array}} codeHashes
+ * @returns {{headId: (ref: string) => string,
+ *            snapshotId: (ref: string, revision: number) => string,
+ *            indexId: (ref: string) => string,
+ *            all: (ref: string, revision?: number) => object}}
+ */
+export function createAddressing(codeHashes) {
+  const object = requireCodeHash(codeHashes, 'object')
+  const snapshot = requireCodeHash(codeHashes, 'snapshot')
+  const index = requireCodeHash(codeHashes, 'index')
+
+  const headId = (ref) => contractId(object, objectParams(ref))
+  const snapshotId = (ref, revision) => contractId(snapshot, snapshotParams(ref, revision))
+  const indexId = (ref) => contractId(index, objectParams(ref))
+
+  return {
+    headId,
+    snapshotId,
+    indexId,
+    /** Every id derivable for a ref, for `ig freenet derive`. */
+    all: (ref, revision) => ({
+      ref,
+      head: headId(ref),
+      index: indexId(ref),
+      ...(revision === undefined ? {} : { revision, snapshot: snapshotId(ref, revision) }),
+    }),
+  }
+}

--- a/src/freenet/base58.js
+++ b/src/freenet/base58.js
@@ -1,0 +1,78 @@
+/**
+ * base58 (Bitcoin alphabet) — how Freenet renders contract instance ids.
+ *
+ * Vendored for the same reason as blake3.js: this package has no runtime
+ * dependencies. Byte-at-a-time long division, so no BigInt and no precision
+ * limits. Leading zero bytes map to leading '1's, as the standard requires.
+ *
+ * Pure and browser-safe.
+ */
+
+const ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
+
+const INDEX = new Map([...ALPHABET].map((c, i) => [c, i]))
+
+/**
+ * @param {Uint8Array} bytes
+ * @returns {string}
+ */
+export function base58Encode(bytes) {
+  if (!(bytes instanceof Uint8Array)) throw new TypeError('base58Encode expects a Uint8Array')
+  if (bytes.length === 0) return ''
+
+  let zeros = 0
+  while (zeros < bytes.length && bytes[zeros] === 0) zeros++
+
+  // log(256)/log(58) ≈ 1.365; 138/100 is the usual safe over-estimate.
+  const size = Math.ceil(((bytes.length - zeros) * 138) / 100) + 1
+  const digits = new Uint8Array(size)
+  let length = 0
+
+  for (let i = zeros; i < bytes.length; i++) {
+    let carry = bytes[i]
+    let j = 0
+    for (let k = size - 1; (carry !== 0 || j < length) && k >= 0; k--, j++) {
+      carry += 256 * digits[k]
+      digits[k] = carry % 58
+      carry = (carry / 58) | 0
+    }
+    length = j
+  }
+
+  let out = '1'.repeat(zeros)
+  for (let k = size - length; k < size; k++) out += ALPHABET[digits[k]]
+  return out
+}
+
+/**
+ * @param {string} str
+ * @returns {Uint8Array}
+ */
+export function base58Decode(str) {
+  if (typeof str !== 'string') throw new TypeError('base58Decode expects a string')
+  if (str.length === 0) return new Uint8Array(0)
+
+  let zeros = 0
+  while (zeros < str.length && str[zeros] === '1') zeros++
+
+  // log(58)/log(256) ≈ 0.733.
+  const size = Math.ceil(((str.length - zeros) * 733) / 1000) + 1
+  const bytes = new Uint8Array(size)
+  let length = 0
+
+  for (let i = zeros; i < str.length; i++) {
+    let carry = INDEX.get(str[i])
+    if (carry === undefined) throw new Error(`Invalid base58 character '${str[i]}' at position ${i}`)
+    let j = 0
+    for (let k = size - 1; (carry !== 0 || j < length) && k >= 0; k--, j++) {
+      carry += 58 * bytes[k]
+      bytes[k] = carry % 256
+      carry = (carry / 256) | 0
+    }
+    length = j
+  }
+
+  const out = new Uint8Array(zeros + length)
+  out.set(bytes.subarray(size - length), zeros)
+  return out
+}

--- a/src/freenet/base58.js
+++ b/src/freenet/base58.js
@@ -1,9 +1,23 @@
 /**
  * base58 (Bitcoin alphabet) — how Freenet renders contract instance ids.
  *
+ * ┌─────────────────────────────────────────────────────────────────────────┐
+ * │ VENDORED CODE — DO NOT HAND-EDIT.                                       │
+ * │                                                                         │
+ * │ Origin:  an independent implementation of the standard base58           │
+ * │          byte-at-a-time long-division algorithm (as described for       │
+ * │          Bitcoin's base58; no third-party code copied).                 │
+ * │ Proof:   validated in test/freenet-hash.test.js against the Bitcoin     │
+ * │          spec vectors, plus round-trips pinning the leading-zero rule   │
+ * │          and rejection of the excluded 0/O/I/l characters.              │
+ * │                                                                         │
+ * │ Re-run those vectors after any change: a base58 bug renders a valid     │
+ * │ address as a plausible-looking wrong one.                              │
+ * └─────────────────────────────────────────────────────────────────────────┘
+ *
  * Vendored for the same reason as blake3.js: this package has no runtime
- * dependencies. Byte-at-a-time long division, so no BigInt and no precision
- * limits. Leading zero bytes map to leading '1's, as the standard requires.
+ * dependencies. Long division byte-at-a-time, so no BigInt and no precision
+ * ceiling. Leading zero bytes map to leading '1's, as the standard requires.
  *
  * Pure and browser-safe.
  */

--- a/src/freenet/blake3.js
+++ b/src/freenet/blake3.js
@@ -1,0 +1,197 @@
+/**
+ * BLAKE3 (256-bit, unkeyed) — the hash Freenet uses for contract addressing.
+ *
+ * Vendored rather than taken as a dependency: this package ships to npm with
+ * zero runtime dependencies, and address derivation is the only thing that
+ * needs BLAKE3. It is a self-contained port of the reference implementation
+ * (https://github.com/BLAKE3-team/BLAKE3, reference_impl.rs), verified against
+ * the project's official test vectors in test/freenet-hash.test.js.
+ *
+ * Scope is deliberately minimal: unkeyed hashing, 32-byte output, one-shot
+ * over an in-memory buffer. No keyed mode, no derive_key, no XOF — none of
+ * which contract addressing uses. Not a general-purpose crypto primitive:
+ * signing in this codebase stays on Web Crypto (src/crypto.js).
+ *
+ * Pure and browser-safe (no node: imports).
+ */
+
+const IV = Int32Array.from([
+  0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a,
+  0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19,
+])
+
+const MSG_PERMUTATION = [2, 6, 3, 10, 7, 0, 4, 13, 1, 11, 12, 5, 9, 14, 15, 8]
+
+const CHUNK_START = 1 << 0
+const CHUNK_END = 1 << 1
+const PARENT = 1 << 2
+const ROOT = 1 << 3
+
+const BLOCK_LEN = 64
+const CHUNK_LEN = 1024
+
+const rotr = (x, n) => (x >>> n) | (x << (32 - n))
+
+/** The BLAKE3 quarter-round (mixing function G). Mutates `s` in place. */
+function g(s, a, b, c, d, mx, my) {
+  s[a] = (s[a] + s[b] + mx) | 0
+  s[d] = rotr(s[d] ^ s[a], 16)
+  s[c] = (s[c] + s[d]) | 0
+  s[b] = rotr(s[b] ^ s[c], 12)
+  s[a] = (s[a] + s[b] + my) | 0
+  s[d] = rotr(s[d] ^ s[a], 8)
+  s[c] = (s[c] + s[d]) | 0
+  s[b] = rotr(s[b] ^ s[c], 7)
+}
+
+/** One of the 7 rounds: four column mixes then four diagonal mixes. */
+function round(s, m) {
+  g(s, 0, 4, 8, 12, m[0], m[1])
+  g(s, 1, 5, 9, 13, m[2], m[3])
+  g(s, 2, 6, 10, 14, m[4], m[5])
+  g(s, 3, 7, 11, 15, m[6], m[7])
+  g(s, 0, 5, 10, 15, m[8], m[9])
+  g(s, 1, 6, 11, 12, m[10], m[11])
+  g(s, 2, 7, 8, 13, m[12], m[13])
+  g(s, 3, 4, 9, 14, m[14], m[15])
+}
+
+function permute(m) {
+  const out = new Int32Array(16)
+  for (let i = 0; i < 16; i++) out[i] = m[MSG_PERMUTATION[i]]
+  return out
+}
+
+/**
+ * The compression function. Returns all 16 output words; callers take the
+ * first 8 as a chaining value, or as the 256-bit root hash.
+ *
+ * @param {Int32Array} cv - 8-word chaining value
+ * @param {Int32Array} block - 16-word (zero-padded) message block
+ * @param {number} counter - chunk counter (u64, but always < 2^53 here)
+ * @param {number} blockLen - bytes of `block` that are real input
+ * @param {number} flags
+ * @returns {Int32Array} 16 words
+ */
+function compress(cv, block, counter, blockLen, flags) {
+  const s = new Int32Array(16)
+  s.set(cv.subarray(0, 8), 0)
+  s.set(IV.subarray(0, 4), 8)
+  s[12] = counter % 0x100000000 | 0
+  s[13] = Math.floor(counter / 0x100000000) | 0
+  s[14] = blockLen
+  s[15] = flags
+
+  let m = block
+  for (let r = 0; r < 7; r++) {
+    round(s, m)
+    if (r < 6) m = permute(m)
+  }
+
+  const out = new Int32Array(16)
+  for (let i = 0; i < 8; i++) {
+    out[i] = s[i] ^ s[i + 8]
+    out[i + 8] = s[i + 8] ^ cv[i]
+  }
+  return out
+}
+
+/** Read `len` bytes at `offset` as 16 little-endian words, zero-padded. */
+function blockWords(buf, offset, len) {
+  const w = new Int32Array(16)
+  for (let i = 0; i < len; i++) w[i >> 2] |= buf[offset + i] << ((i & 3) * 8)
+  return w
+}
+
+/**
+ * A deferred final compression. The tree can't know whether a node is the
+ * root until the whole input is consumed, and the root flag changes the
+ * output — so nodes carry their inputs and compress on demand.
+ */
+function makeOutput(inputCv, block, counter, blockLen, flags) {
+  return { inputCv, block, counter, blockLen, flags }
+}
+
+function chainingValue(o) {
+  return compress(o.inputCv, o.block, o.counter, o.blockLen, o.flags).subarray(0, 8)
+}
+
+/** Compress as the root node and serialize the first 8 words little-endian. */
+function rootBytes(o) {
+  const words = compress(o.inputCv, o.block, o.counter, o.blockLen, o.flags | ROOT)
+  const out = new Uint8Array(32)
+  for (let i = 0; i < 8; i++) {
+    for (let b = 0; b < 4; b++) out[i * 4 + b] = (words[i] >>> (b * 8)) & 0xff
+  }
+  return out
+}
+
+/** Hash one chunk (≤ 1024 bytes) into a deferred output node. */
+function chunkOutput(buf, offset, len, counter) {
+  let cv = IV
+  let pos = 0
+  let blocks = 0
+
+  while (len - pos > BLOCK_LEN) {
+    const flags = blocks === 0 ? CHUNK_START : 0
+    cv = compress(cv, blockWords(buf, offset + pos, BLOCK_LEN), counter, BLOCK_LEN, flags).subarray(0, 8)
+    pos += BLOCK_LEN
+    blocks++
+  }
+
+  // The final block — short, full, or (for empty input) zero-length.
+  const lastLen = len - pos
+  const flags = (blocks === 0 ? CHUNK_START : 0) | CHUNK_END
+  return makeOutput(cv, blockWords(buf, offset + pos, lastLen), counter, lastLen, flags)
+}
+
+function parentOutput(leftCv, rightCv) {
+  const block = new Int32Array(16)
+  block.set(leftCv, 0)
+  block.set(rightCv, 8)
+  return makeOutput(IV, block, 0, BLOCK_LEN, PARENT)
+}
+
+/**
+ * Bytes in the left subtree: the largest power-of-two number of chunks
+ * strictly below the total, so the left side is always a perfect subtree.
+ */
+function leftLen(contentLen) {
+  const fullChunks = Math.floor((contentLen - 1) / CHUNK_LEN)
+  let p = 1
+  while (p * 2 <= fullChunks) p *= 2
+  return p * CHUNK_LEN
+}
+
+/** Recursively hash [offset, offset+len) into a deferred output node. */
+function hashTree(buf, offset, len, chunkCounter) {
+  if (len <= CHUNK_LEN) return chunkOutput(buf, offset, len, chunkCounter)
+
+  const split = leftLen(len)
+  const left = chainingValue(hashTree(buf, offset, split, chunkCounter))
+  const right = chainingValue(hashTree(buf, offset + split, len - split, chunkCounter + split / CHUNK_LEN))
+  return parentOutput(left, right)
+}
+
+/**
+ * BLAKE3-256 of a buffer.
+ * @param {Uint8Array} input
+ * @returns {Uint8Array} 32 bytes
+ */
+export function blake3(input) {
+  if (!(input instanceof Uint8Array)) throw new TypeError('blake3 expects a Uint8Array')
+  return rootBytes(hashTree(input, 0, input.length, 0))
+}
+
+/** BLAKE3-256 of several buffers concatenated, without materializing the join. */
+export function blake3Concat(...parts) {
+  let total = 0
+  for (const p of parts) total += p.length
+  const buf = new Uint8Array(total)
+  let at = 0
+  for (const p of parts) {
+    buf.set(p, at)
+    at += p.length
+  }
+  return blake3(buf)
+}

--- a/src/freenet/blake3.js
+++ b/src/freenet/blake3.js
@@ -1,16 +1,37 @@
 /**
  * BLAKE3 (256-bit, unkeyed) — the hash Freenet uses for contract addressing.
  *
- * Vendored rather than taken as a dependency: this package ships to npm with
- * zero runtime dependencies, and address derivation is the only thing that
- * needs BLAKE3. It is a self-contained port of the reference implementation
- * (https://github.com/BLAKE3-team/BLAKE3, reference_impl.rs), verified against
- * the project's official test vectors in test/freenet-hash.test.js.
+ * ┌─────────────────────────────────────────────────────────────────────────┐
+ * │ VENDORED CODE — DO NOT HAND-EDIT.                                       │
+ * │                                                                         │
+ * │ Origin:  the BLAKE3 reference implementation, reference_impl.rs         │
+ * │          https://github.com/BLAKE3-team/BLAKE3 (ported to JS)           │
+ * │ Licence: the reference implementation is dual-licensed CC0-1.0 and      │
+ * │          Apache-2.0; this port is distributed under the package's       │
+ * │          GPL-3.0-only, which both permit.                               │
+ * │ Proof:   validated against the project's OFFICIAL test vectors — see    │
+ * │          test/freenet-hash.test.js, 23 cases spanning every structural  │
+ * │          boundary (empty, sub-block, exact block, chunk boundaries at   │
+ * │          1023/1024/1025, multi-level merkle trees to 102400 bytes).     │
+ * │                                                                         │
+ * │ Changing anything here without re-running those vectors risks silently  │
+ * │ relocating every contract address. Fix bugs upstream-style: adjust to   │
+ * │ match the reference, then let the vectors confirm it.                   │
+ * └─────────────────────────────────────────────────────────────────────────┘
+ *
+ * Why vendored at all: this package ships to npm with ZERO runtime
+ * dependencies, and address derivation is the only thing that needs BLAKE3.
+ * Taking @noble/hashes would push a transitive dependency onto every consumer
+ * of the library for a feature most never touch. If that trade-off is ever
+ * judged the wrong way round, it is a one-line swap — this module's only
+ * export used elsewhere is `blake3(Uint8Array) -> Uint8Array`.
  *
  * Scope is deliberately minimal: unkeyed hashing, 32-byte output, one-shot
  * over an in-memory buffer. No keyed mode, no derive_key, no XOF — none of
- * which contract addressing uses. Not a general-purpose crypto primitive:
- * signing in this codebase stays on Web Crypto (src/crypto.js).
+ * which contract addressing uses, and every line that isn't here can't be
+ * wrong. NOT a general-purpose crypto primitive, and not security-critical:
+ * it derives addresses, not signatures. Signing stays on Web Crypto
+ * (src/crypto.js) and is untouched.
  *
  * Pure and browser-safe (no node: imports).
  */

--- a/src/freenet/config.js
+++ b/src/freenet/config.js
@@ -1,0 +1,90 @@
+/**
+ * Freenet backend configuration.
+ *
+ * Stored the way every other ig setting is: one flat file per key under
+ * <configDir>/config/. The reader is injected rather than imported so this
+ * module stays free of node:fs and of cli/runtime.js (which imports from
+ * src/, not the other way round).
+ *
+ * Precedence: command-line flag > stored config > default.
+ */
+
+export const FREENET_CONFIG_KEYS = {
+  port: 'freenet-port',
+  fdev: 'freenet-fdev',
+  contractsDir: 'freenet-contracts-dir',
+}
+
+/** The node's ws-api port used by the dataverse spike work. */
+export const DEFAULT_PORT = 7509
+
+/**
+ * Read timeout. A GET for a contract the node doesn't hold does not fail
+ * fast — it blocks for the host's network fetch budget (minutes). Bounding
+ * it is what turns "hung terminal" into a diagnosable error.
+ */
+export const DEFAULT_TIMEOUT_MS = 60_000
+
+/**
+ * Write timeout. A PUT round-trips ring placement against the node's own
+ * ~300 s budget, so this has to sit above it or we would report failures the
+ * node was still working on.
+ */
+export const DEFAULT_PUT_TIMEOUT_MS = 330_000
+
+/**
+ * DEV-2: the bounded local-presence probe before a poke. A locally hosted
+ * contract answers in well under a second, so 5 s cleanly separates "already
+ * here" from "would go to the network" without ever waiting out the fetch
+ * budget. Deliberately not configurable — it is a semantic constant of the
+ * poke flow, not a tuning knob.
+ */
+export const PROBE_TIMEOUT_MS = 5_000
+
+function positiveInt(value, label) {
+  const n = typeof value === 'number' ? value : Number(String(value).trim())
+  if (!Number.isInteger(n) || n <= 0) {
+    throw new Error(`Invalid ${label}: ${JSON.stringify(value)} — expected a positive integer`)
+  }
+  return n
+}
+
+/**
+ * @param {(key: string) => (string|null)} read - stored-config getter
+ * @param {object} flags - parsed command-line overrides
+ * @returns {{port: number, fdevPath: string, contractsDir: string,
+ *            timeoutMs: number, putTimeoutMs: number}}
+ */
+export function resolveFreenetConfig(read, flags = {}) {
+  const stored = (key) => {
+    const v = read(key)
+    return v === null || v === undefined || v === '' ? null : v
+  }
+
+  const contractsDir = flags.contractsDir ?? stored(FREENET_CONFIG_KEYS.contractsDir)
+  if (!contractsDir) {
+    throw new Error(
+      'Freenet contracts directory is not configured.\n' +
+      `  Set it with:  ig freenet config ${FREENET_CONFIG_KEYS.contractsDir} <dir>\n` +
+      '  Or pass:      --contracts-dir <dir>\n' +
+      'The directory must hold the pinned contract WASMs: dataverse_object.wasm,\n' +
+      'dataverse_object_rev.wasm, dataverse_inbound_index.wasm.',
+    )
+  }
+
+  const rawPort = flags.port ?? stored(FREENET_CONFIG_KEYS.port) ?? DEFAULT_PORT
+  const port = positiveInt(rawPort, 'Freenet port')
+  if (port > 65535) throw new Error(`Invalid Freenet port: ${port} — expected a positive integer below 65536`)
+
+  return {
+    port,
+    fdevPath: flags.fdev ?? stored(FREENET_CONFIG_KEYS.fdev) ?? 'fdev',
+    contractsDir,
+    timeoutMs: flags.timeout === undefined
+      ? DEFAULT_TIMEOUT_MS
+      : positiveInt(flags.timeout, 'timeout') * 1000,
+    putTimeoutMs: flags.putTimeout === undefined
+      ? DEFAULT_PUT_TIMEOUT_MS
+      : positiveInt(flags.putTimeout, 'put-timeout') * 1000,
+  }
+}

--- a/src/freenet/contracts.js
+++ b/src/freenet/contracts.js
@@ -1,0 +1,59 @@
+/**
+ * The pinned contract WASMs.
+ *
+ * These bytes ARE the keyspace: a contract's id hashes its code, so a
+ * different build of the same contract addresses a different, empty universe
+ * (an existing object would silently look unpublished). They are therefore
+ * pinned artifacts to be read, never rebuilt on the fly — which is why the
+ * directory is configuration rather than something we go looking for.
+ */
+
+import { readFileSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+import { blake3 } from './blake3.js'
+
+/** Contract role → file name in the contracts directory. */
+export const CONTRACT_FILES = {
+  object: 'dataverse_object.wasm',
+  snapshot: 'dataverse_object_rev.wasm',
+  index: 'dataverse_inbound_index.wasm',
+}
+
+/**
+ * Read and hash the three contract WASMs.
+ *
+ * @param {string} contractsDir
+ * @returns {{paths: Record<string,string>, codeHashes: Record<string,Uint8Array>, dir: string}}
+ */
+export function loadContracts(contractsDir) {
+  let st
+  try {
+    st = statSync(contractsDir)
+  } catch {
+    throw new Error(
+      `Freenet contracts directory does not exist: ${contractsDir}\n` +
+      '  Point --contracts-dir (or the freenet-contracts-dir config key) at the\n' +
+      '  directory holding the pinned contract WASMs.',
+    )
+  }
+  if (!st.isDirectory()) throw new Error(`Freenet contracts path is not a directory: ${contractsDir}`)
+
+  const paths = {}
+  const codeHashes = {}
+  for (const [role, file] of Object.entries(CONTRACT_FILES)) {
+    const path = join(contractsDir, file)
+    let bytes
+    try {
+      bytes = readFileSync(path)
+    } catch {
+      throw new Error(
+        `Missing contract WASM: ${file}\n` +
+        `  Looked in: ${contractsDir}\n` +
+        `  Expected all of: ${Object.values(CONTRACT_FILES).join(', ')}`,
+      )
+    }
+    paths[role] = path
+    codeHashes[role] = blake3(new Uint8Array(bytes.buffer, bytes.byteOffset, bytes.byteLength))
+  }
+  return { paths, codeHashes, dir: contractsDir }
+}

--- a/src/freenet/fdev.js
+++ b/src/freenet/fdev.js
@@ -39,6 +39,19 @@ const seconds = (ms) => `${Math.round(ms / 1000)}s`
  * and a SIGKILL carries none. The process-level bound is then set ABOVE it as
  * a pure backstop for an fdev that ignores its own deadline.
  */
+/**
+ * How fdev words the two outcomes that must never be confused (captured from
+ * fdev 0.3.274, 2026-07-28):
+ *
+ *   absent      "client error: missing contract: <id>"
+ *   unreachable "failed to connect to the host(ws://…): IO error: Connection refused"
+ *
+ * Treating an unreachable node as "absent" is the dangerous direction: the
+ * publish flow would conclude no index exists and start creating them.
+ */
+const ABSENT_RE = /missing contract|contract not found|not found/i
+const UNREACHABLE_RE = /failed to connect to the host|connection refused|connection reset|no route to host|broken pipe/i
+
 const FDEV_TIMEOUT_GRACE_MS = 10_000
 const fdevTimeoutArgs = (ms) => ['--timeout', String(Math.max(1, Math.ceil(ms / 1000)))]
 const processBound = (ms) => ms + FDEV_TIMEOUT_GRACE_MS
@@ -53,7 +66,10 @@ function defaultExec(file, args, { timeoutMs }) {
       file, args,
       { timeout: timeoutMs, killSignal: 'SIGKILL', maxBuffer: 64 * 1024 * 1024 },
       (err, stdout, stderr) => {
-        if (err && err.code === 'ENOENT') {
+        // execFile reports a failed SPAWN with a string code (ENOENT, EACCES,
+        // EPERM, …) and a non-zero EXIT with a number. Keying on ENOENT alone
+        // would let an unexecutable fdev fall through as a contract miss.
+        if (err && typeof err.code === 'string' && !err.killed) {
           return resolve({ code: null, stdout: '', stderr: '', timedOut: false, spawnError: err })
         }
         resolve({
@@ -175,10 +191,30 @@ export function createFdevNode({
       } catch { /* no output file — a miss */ }
 
       if (res.code !== 0 || !raw) {
+        const stderr = `${res.stderr}\n${res.stdout}`
+        // An unreachable node must never read as "this contract is absent" —
+        // the publish flow would take that as licence to create indexes.
+        if (UNREACHABLE_RE.test(stderr)) {
+          throw new Error(
+            `Could not reach a Freenet node on 127.0.0.1:${port}.\n` +
+            `  ${tail(stderr, 3)}\n` +
+            `  Check the node is running and listening on port ${port}, or set a different one:\n` +
+            `    ig freenet config ${FREENET_CONFIG_KEYS.port} <port>`,
+          )
+        }
+        // Only an explicit absence counts as absence. Anything else is an
+        // operational failure and is surfaced rather than silently swallowed.
+        if (res.code !== 0 && !ABSENT_RE.test(stderr)) {
+          throw new Error(
+            `fdev GET of ${id} failed (exit ${res.code}) on 127.0.0.1:${port}:\n` +
+            tail(stderr, 5).split('\n').map(l => `  ${l}`).join('\n'),
+          )
+        }
         return {
           found: false,
           state: null,
           timedOut: false,
+          operational: false,
           detail: `no state returned for ${id} — not found on the node` +
             (res.code !== 0 && tail(res.stderr, 3) ? `\n  ${tail(res.stderr, 3)}` : ''),
         }

--- a/src/freenet/fdev.js
+++ b/src/freenet/fdev.js
@@ -1,0 +1,245 @@
+/**
+ * The Freenet node client: `fdev` driven as a subprocess.
+ *
+ * fdev is the only supported way to talk to a node's ws-api, so this wraps it
+ * rather than reimplementing the protocol. The invocations mirror the spike's
+ * shell scripts exactly (scripts/lib.sh) — a drifted flag would address the
+ * wrong keyspace and look like a missing object.
+ *
+ * Two things this layer exists to guarantee:
+ *
+ *   1. EVERY node call is bounded. A GET for a contract the node doesn't hold
+ *      does not fail fast: it blocks for the host's multi-minute network fetch
+ *      budget. Unbounded, that reads as a hung terminal.
+ *   2. Every failure comes back diagnosable. "fdev exited 1" tells a user
+ *      nothing; missing binary, timeout, node refusal and plain not-found are
+ *      four different problems with four different fixes.
+ *
+ * `exec` is injected so the whole surface is testable without a node.
+ */
+
+import { execFile } from 'node:child_process'
+import { mkdtempSync, writeFileSync, readFileSync, rmSync, statSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { DEFAULT_TIMEOUT_MS, DEFAULT_PUT_TIMEOUT_MS, PROBE_TIMEOUT_MS, FREENET_CONFIG_KEYS } from './config.js'
+
+const stripAnsi = (s) => String(s ?? '').replace(/\[[0-9;]*m/g, '')
+
+/** Last few meaningful lines of fdev output — enough to diagnose, not a wall. */
+function tail(text, lines = 6) {
+  return stripAnsi(text).split('\n').map(l => l.trimEnd()).filter(Boolean).slice(-lines).join('\n')
+}
+
+const seconds = (ms) => `${Math.round(ms / 1000)}s`
+
+/**
+ * fdev takes its own deadline in whole seconds (`--timeout`, default 300 s).
+ * We always pass it, because a clean fdev give-up carries a real explanation
+ * and a SIGKILL carries none. The process-level bound is then set ABOVE it as
+ * a pure backstop for an fdev that ignores its own deadline.
+ */
+const FDEV_TIMEOUT_GRACE_MS = 10_000
+const fdevTimeoutArgs = (ms) => ['--timeout', String(Math.max(1, Math.ceil(ms / 1000)))]
+const processBound = (ms) => ms + FDEV_TIMEOUT_GRACE_MS
+
+/**
+ * Default exec: run a command, capture output, never reject.
+ * Timeouts kill with SIGKILL — fdev must not be able to outlive its bound.
+ */
+function defaultExec(file, args, { timeoutMs }) {
+  return new Promise((resolve) => {
+    execFile(
+      file, args,
+      { timeout: timeoutMs, killSignal: 'SIGKILL', maxBuffer: 64 * 1024 * 1024 },
+      (err, stdout, stderr) => {
+        if (err && err.code === 'ENOENT') {
+          return resolve({ code: null, stdout: '', stderr: '', timedOut: false, spawnError: err })
+        }
+        resolve({
+          code: err ? (typeof err.code === 'number' ? err.code : null) : 0,
+          stdout: stdout ?? '',
+          stderr: stderr ?? '',
+          timedOut: !!(err && err.killed),
+          spawnError: null,
+        })
+      },
+    )
+  })
+}
+
+/** Serialize a state/payload argument to the bytes fdev should send. */
+function toBytes(value) {
+  if (value instanceof Uint8Array) return value
+  if (typeof value === 'string') return new TextEncoder().encode(value)
+  return new TextEncoder().encode(JSON.stringify(value))
+}
+
+/**
+ * @param {object} opts
+ * @param {string} opts.fdevPath
+ * @param {number} opts.port
+ * @param {Function} [opts.exec] - injected runner (tests)
+ * @param {number} [opts.timeoutMs] - read timeout
+ * @param {number} [opts.putTimeoutMs] - write timeout
+ * @param {number} [opts.probeTimeoutMs] - DEV-2 local-presence probe
+ */
+export function createFdevNode({
+  fdevPath,
+  port,
+  exec = defaultExec,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+  putTimeoutMs = DEFAULT_PUT_TIMEOUT_MS,
+  probeTimeoutMs = PROBE_TIMEOUT_MS,
+}) {
+  /** Run fdev in a scratch dir that is always cleaned up. */
+  async function run(args, { timeoutMs: limit, files = {} }) {
+    const dir = mkdtempSync(join(tmpdir(), 'ig-freenet-'))
+    try {
+      const paths = {}
+      for (const [name, bytes] of Object.entries(files)) {
+        paths[name] = join(dir, name)
+        writeFileSync(paths[name], bytes)
+      }
+      const full = args(paths, dir)
+      const res = await exec(fdevPath, full, { timeoutMs: processBound(limit) })
+      if (res.spawnError) {
+        throw new Error(
+          `Could not run fdev at '${fdevPath}': ${res.spawnError.code === 'ENOENT' ? 'not found' : res.spawnError.message}\n` +
+          `  Install fdev, put it on your PATH, or set its location:\n` +
+          `    ig freenet config ${FREENET_CONFIG_KEYS.fdev} /path/to/fdev`,
+        )
+      }
+      return { ...res, dir, paths }
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  }
+
+  /** Shared failure text for writes — the two fixes are port and node health. */
+  function writeFailure(what, res, limit) {
+    if (res.timedOut) {
+      return new Error(
+        `${what} timed out after ${seconds(limit)} on 127.0.0.1:${port}.\n` +
+        '  The node may be unreachable, or its ring placement may be stalled.\n' +
+        `  Check the node is listening on port ${port} (fdev query), then retry — the flow is idempotent.`,
+      )
+    }
+    const detail = tail(`${res.stderr}\n${res.stdout}`)
+    return new Error(
+      `${what} failed (fdev exit ${res.code ?? 'unknown'}) on 127.0.0.1:${port}` +
+      (detail ? `:\n${detail.split('\n').map(l => `  ${l}`).join('\n')}` : '.'),
+    )
+  }
+
+  /**
+   * GET a contract's state.
+   *
+   * Never throws for a miss — absence is meaningful (a never-published
+   * revision, an index nobody has poked), so callers decide what it means.
+   * Reads the --output file before the scratch dir is torn down.
+   *
+   * @returns {Promise<{found: boolean, state: object|null, timedOut: boolean, detail: string}>}
+   */
+  async function getState(id, limit) {
+    const dir = mkdtempSync(join(tmpdir(), 'ig-freenet-'))
+    const outPath = join(dir, 'state.json')
+    try {
+      const res = await exec(
+        fdevPath,
+        ['-p', String(port), 'execute', 'get', id, '--output', outPath, ...fdevTimeoutArgs(limit)],
+        { timeoutMs: processBound(limit) },
+      )
+      if (res.spawnError) {
+        throw new Error(
+          `Could not run fdev at '${fdevPath}': ${res.spawnError.code === 'ENOENT' ? 'not found' : res.spawnError.message}\n` +
+          '  Install fdev, put it on your PATH, or set its location:\n' +
+          `    ig freenet config ${FREENET_CONFIG_KEYS.fdev} /path/to/fdev`,
+        )
+      }
+      if (res.timedOut) {
+        return {
+          found: false,
+          state: null,
+          timedOut: true,
+          detail:
+            `GET timed out after ${seconds(limit)}. On a connected node, a contract the node does not ` +
+            'hold locally blocks for the network fetch budget (minutes) — so this is probably absent, ' +
+            'but it is not proof. Raise --timeout to wait longer.',
+        }
+      }
+
+      let raw = null
+      try {
+        if (statSync(outPath).size > 0) raw = readFileSync(outPath, 'utf-8')
+      } catch { /* no output file — a miss */ }
+
+      if (res.code !== 0 || !raw) {
+        return {
+          found: false,
+          state: null,
+          timedOut: false,
+          detail: `no state returned for ${id} — not found on the node` +
+            (res.code !== 0 && tail(res.stderr, 3) ? `\n  ${tail(res.stderr, 3)}` : ''),
+        }
+      }
+      try {
+        return { found: true, state: JSON.parse(raw), timedOut: false, detail: '', raw }
+      } catch (err) {
+        throw new Error(`Contract ${id} returned state that is not JSON: ${err.message}`)
+      }
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  }
+
+  return {
+    port,
+    fdevPath,
+    timeoutMs,
+    putTimeoutMs,
+
+    get: (id, opts = {}) => getState(id, opts.timeoutMs ?? timeoutMs),
+
+    /**
+     * DEV-2 local-presence probe: bounded hard at 5 s. A locally hosted
+     * contract answers in well under a second; anything slower is treated as
+     * absent rather than waiting out the node's fetch budget.
+     */
+    probe: (id) => getState(id, probeTimeoutMs),
+
+    /** PUT — creates the contract, or is an idempotent no-op / LWW merge. */
+    async publish({ wasmPath, params, state }) {
+      const res = await run(
+        (paths) => [
+          '-p', String(port), 'publish',
+          '--code', wasmPath,
+          '--parameters', paths['params.bin'],
+          // --timeout is an option of `publish`, so it precedes the subcommand.
+          ...fdevTimeoutArgs(putTimeoutMs),
+          'contract',
+          '--state', paths['state.json'],
+        ],
+        {
+          timeoutMs: putTimeoutMs,
+          files: { 'params.bin': params, 'state.json': toBytes(state) },
+        },
+      )
+      if (res.timedOut || res.code !== 0) throw writeFailure('PUT', res, putTimeoutMs)
+      return { ok: true, output: tail(`${res.stdout}\n${res.stderr}`) }
+    },
+
+    /** UPDATE — sends a delta to an existing contract. */
+    async update(id, payload) {
+      const res = await run(
+        (paths) => [
+          '-p', String(port), 'execute', 'update', id, paths['payload.json'],
+          ...fdevTimeoutArgs(putTimeoutMs),
+        ],
+        { timeoutMs: putTimeoutMs, files: { 'payload.json': toBytes(payload) } },
+      )
+      if (res.timedOut || res.code !== 0) throw writeFailure(`UPDATE of ${id}`, res, putTimeoutMs)
+      return { ok: true, output: tail(`${res.stdout}\n${res.stderr}`) }
+    },
+  }
+}

--- a/src/freenet/fdev.js
+++ b/src/freenet/fdev.js
@@ -49,7 +49,7 @@ const seconds = (ms) => `${Math.round(ms / 1000)}s`
  * Treating an unreachable node as "absent" is the dangerous direction: the
  * publish flow would conclude no index exists and start creating them.
  */
-const ABSENT_RE = /missing contract|contract not found|not found/i
+const ABSENT_RE = /missing contract|contract not found/i
 const UNREACHABLE_RE = /failed to connect to the host|connection refused|connection reset|no route to host|broken pipe/i
 
 const FDEV_TIMEOUT_GRACE_MS = 10_000
@@ -203,11 +203,16 @@ export function createFdevNode({
           )
         }
         // Only an explicit absence counts as absence. Anything else is an
-        // operational failure and is surfaced rather than silently swallowed.
-        if (res.code !== 0 && !ABSENT_RE.test(stderr)) {
+        // operational failure and is surfaced rather than silently swallowed —
+        // including exit 0 with nothing written, which fdev never does for a
+        // real miss (a miss is exit 1 plus "missing contract", verified
+        // against 0.3.274). Guessing "absent" is the dangerous guess: it is
+        // what licenses the publish flow to start creating index contracts.
+        if (!ABSENT_RE.test(stderr)) {
           throw new Error(
-            `fdev GET of ${id} failed (exit ${res.code}) on 127.0.0.1:${port}:\n` +
-            tail(stderr, 5).split('\n').map(l => `  ${l}`).join('\n'),
+            `fdev GET of ${id} returned no state on 127.0.0.1:${port} ` +
+            `(exit ${res.code ?? 'unknown'}), without reporting the contract as missing:\n` +
+            (tail(stderr, 5) || '  (no output)').split('\n').map(l => `  ${l.trim()}`).join('\n'),
           )
         }
         return {

--- a/src/freenet/publish.js
+++ b/src/freenet/publish.js
@@ -57,6 +57,38 @@ async function pokeTarget({ target, sourceRef, revision, node, addressing, contr
 }
 
 /**
+ * Relation targets of the head we are about to replace, so targets dropped in
+ * this revision can still be poked (US-2.4).
+ *
+ * Only a head STRICTLY OLDER than ours is a predecessor. An equal-or-newer
+ * head is either our own re-publish or someone else's state; diffing against
+ * it would poke targets we never dropped.
+ *
+ * @returns {Promise<string[]>}
+ */
+async function previousTargets({ headId, revision, node, log }) {
+  let previous
+  try {
+    previous = await node.probe(headId)
+  } catch (err) {
+    // An unreachable node is about to fail the head PUT anyway; don't fail
+    // here, where the only cost is losing tombstones.
+    log(`   (could not read the previous head: ${err.message.split('\n')[0]})`)
+    return []
+  }
+  if (!previous.found) return []
+
+  let previousRevision
+  try {
+    previousRevision = envelopeRevision(previous.state)
+  } catch {
+    return []
+  }
+  if (previousRevision >= revision) return []
+  return relationTargets(previous.state)
+}
+
+/**
  * @param {object} opts
  * @param {object} opts.envelope - the signed object to publish
  * @param {object} opts.node - fdev node client
@@ -110,6 +142,18 @@ export async function publishObject({ envelope, node, addressing, contracts, log
   }
   log('   confirmed: the node holds our signature')
 
+  // ── 2b. read the previous head, before we overwrite it ─────────
+  // US-2.4: when a revision DROPS a relation, the target's index only learns
+  // about it if we poke that target too — the index fetches our new snapshot,
+  // finds no relation to itself, and writes {revision: N+1, relations: []}.
+  // Without this the removal never propagates and the index stays wrong.
+  //
+  // Bounded like the DEV-2 probe, and for the same reason: on a first publish
+  // there is no previous head, and an unbounded miss would block for the
+  // node's fetch budget. A miss simply means no tombstones — the head we
+  // cannot read is one we cannot diff against.
+  const droppedTargets = await previousTargets({ headId, revision, node, log })
+
   // ── 3. head PUT ────────────────────────────────────────────────
   log(`── 3/4 head PUT       ${headId}`)
   await node.publish({
@@ -130,23 +174,31 @@ export async function publishObject({ envelope, node, addressing, contracts, log
   log(`   head: ${headState.confirmed ? 'confirmed' : `⚠ ${headState.detail}`}`)
 
   // ── 4. pokes ───────────────────────────────────────────────────
-  const targets = relationTargets(envelope)
-  log(`── 4/4 poking ${targets.length} distinct relation target(s)`)
+  const current = relationTargets(envelope)
+  const currentSet = new Set(current)
+  const tombstones = droppedTargets.filter(t => !currentSet.has(t))
+  const targets = [...current, ...tombstones].sort()
+  log(
+    `── 4/4 poking ${targets.length} distinct relation target(s)` +
+    (tombstones.length ? `, ${tombstones.length} of them dropped since revision ${revision}` : ''),
+  )
 
   const pokes = []
   for (const target of targets) {
+    const tombstone = !currentSet.has(target)
     try {
       const { indexId, created } = await pokeTarget({
         target, sourceRef: ref, revision, node, addressing, contracts, log,
       })
-      pokes.push({ target, indexId, created, ok: true, error: null })
-      log(`   ✓ ${target}`)
+      pokes.push({ target, indexId, created, tombstone, ok: true, error: null })
+      log(`   ✓ ${target}${tombstone ? '  (relation dropped — tombstoning)' : ''}`)
     } catch (err) {
-      pokes.push({ target, indexId: null, created: false, ok: false, error: err.message })
+      pokes.push({ target, indexId: null, created: false, tombstone, ok: false, error: err.message })
       log(`   ✗ ${target}  (${err.message.split('\n')[0]})`)
     }
   }
 
+  const failed = pokes.filter(p => !p.ok).length
   return {
     ref,
     revision,
@@ -154,6 +206,10 @@ export async function publishObject({ envelope, node, addressing, contracts, log
     headId,
     headState,
     pokes,
-    failed: pokes.filter(p => !p.ok).length,
+    failed,
+    // Success means the object is actually live: the head is confirmed AND
+    // every index was told about it. A confirmed-nothing head with happy
+    // pokes is not a success, however green the poke report looks.
+    ok: failed === 0 && headState.confirmed,
   }
 }

--- a/src/freenet/publish.js
+++ b/src/freenet/publish.js
@@ -18,7 +18,7 @@
  */
 
 import { objectParams, snapshotParams, parseRef } from './addressing.js'
-import { relationTargets, envelopeRef, envelopeRevision } from './relations.js'
+import { relationTargets, relationKey as refKey, envelopeRef, envelopeRevision } from './relations.js'
 
 /** The initial state of an index nobody has poked yet (D2 wire format). */
 const EMPTY_INDEX = { v: 1, slots: {} }
@@ -175,8 +175,12 @@ export async function publishObject({ envelope, node, addressing, contracts, log
 
   // ── 4. pokes ───────────────────────────────────────────────────
   const current = relationTargets(envelope)
-  const currentSet = new Set(current)
-  const tombstones = droppedTargets.filter(t => !currentSet.has(t))
+  // Compared by the contract's own notion of "same object" (derived bytes),
+  // not by ref string: a ref merely RESPELLED between revisions (uuid case)
+  // points at the same index and has not been dropped. Comparing strings
+  // would poke it twice and mislabel one of them a tombstone.
+  const currentSet = new Set(current.map(refKey))
+  const tombstones = droppedTargets.filter(t => !currentSet.has(refKey(t)))
   const targets = [...current, ...tombstones].sort()
   log(
     `── 4/4 poking ${targets.length} distinct relation target(s)` +
@@ -185,7 +189,7 @@ export async function publishObject({ envelope, node, addressing, contracts, log
 
   const pokes = []
   for (const target of targets) {
-    const tombstone = !currentSet.has(target)
+      const tombstone = !currentSet.has(refKey(target))
     try {
       const { indexId, created } = await pokeTarget({
         target, sourceRef: ref, revision, node, addressing, contracts, log,

--- a/src/freenet/publish.js
+++ b/src/freenet/publish.js
@@ -1,0 +1,159 @@
+/**
+ * The US-3.1 ordered publish flow.
+ *
+ *   1. PUT the revision snapshot (ref, rev)             [immutable]
+ *   2. confirm the snapshot GETs back                   [gate — abort here]
+ *   3. PUT/update the head                              [mutable, LWW]
+ *   4. poke the inbound index of every distinct target in item.relations
+ *
+ * The order is load-bearing. A poke makes the target's index `requires()` the
+ * SOURCE's snapshot; poking before that snapshot is confirmed present stalls
+ * each poke for the host's ~240 s fetch budget and then fails (spike finding).
+ * Step 2 is cheap insurance against paying that per target.
+ *
+ * Pokes are independent: one failure does not stop the rest. The caller gets a
+ * per-target report and decides the exit code. Partial success is normal and
+ * the whole flow is idempotent — snapshot re-PUT is a no-op, head merge is
+ * LWW, pokes are LWW — so re-running converges.
+ */
+
+import { objectParams, snapshotParams, parseRef } from './addressing.js'
+import { relationTargets, envelopeRef, envelopeRevision } from './relations.js'
+
+/** The initial state of an index nobody has poked yet (D2 wire format). */
+const EMPTY_INDEX = { v: 1, slots: {} }
+
+const pokePayload = (sourceRef, revision) => ({ v: 1, poke: { source_ref: sourceRef, revision } })
+
+/**
+ * Ensure the target's index contract exists, then poke it.
+ *
+ * DEV-2: probe local presence with a tightly bounded GET before publishing.
+ * A locally hosted contract answers in well under a second, so the probe
+ * separates "already here" from "would go to the network" without waiting out
+ * the fetch budget. Skipping the re-publish on a hit matters — a publish
+ * round-trips ring placement, which fails spuriously when the index's
+ * neighbourhood is unreachable, killing a poke that would have succeeded
+ * (observed live 2026-06-12). A miss, including a slow-node false negative,
+ * falls back to the idempotent empty publish.
+ */
+async function pokeTarget({ target, sourceRef, revision, node, addressing, contracts, log }) {
+  parseRef(target) // fail early, with a message naming the bad ref
+  const indexId = addressing.indexId(target)
+
+  const probe = await node.probe(indexId)
+  const created = !probe.found
+  if (created) {
+    log(`   index not on node — creating empty: ${indexId}`)
+    await node.publish({
+      wasmPath: contracts.paths.index,
+      params: objectParams(target),
+      state: EMPTY_INDEX,
+    })
+  }
+
+  await node.update(indexId, pokePayload(sourceRef, revision))
+  return { indexId, created }
+}
+
+/**
+ * @param {object} opts
+ * @param {object} opts.envelope - the signed object to publish
+ * @param {object} opts.node - fdev node client
+ * @param {object} opts.addressing - from createAddressing()
+ * @param {object} opts.contracts - from loadContracts()
+ * @param {(msg: string) => void} [opts.log] - progress output (stderr)
+ * @returns {Promise<object>} per-target report
+ */
+export async function publishObject({ envelope, node, addressing, contracts, log = () => {} }) {
+  const ref = envelopeRef(envelope)
+  const revision = envelopeRevision(envelope)
+  const signature = envelope?.signature
+  if (!signature) {
+    throw new Error(
+      `Envelope for ${ref} has no signature — refusing to publish.\n` +
+      '  Only signed objects can be verified by the contract; sign it with `ig sign` first.',
+    )
+  }
+  parseRef(ref)
+
+  const snapshotId = addressing.snapshotId(ref, revision)
+  const headId = addressing.headId(ref)
+
+  // ── 1. snapshot PUT ────────────────────────────────────────────
+  log(`── 1/4 snapshot PUT   ${snapshotId}  (rev ${revision})`)
+  await node.publish({
+    wasmPath: contracts.paths.snapshot,
+    params: snapshotParams(ref, revision),
+    state: envelope,
+  })
+
+  // ── 2. GET-back gate ───────────────────────────────────────────
+  // Compare by SIGNATURE, not bytes: the signature is over the canonical
+  // item, so two different serializations of the same signed object are the
+  // same object and must not read as a conflict.
+  log('── 2/4 snapshot GET-back confirm')
+  const back = await node.get(snapshotId)
+  if (!back.found) {
+    throw new Error(
+      `Snapshot did not GET back (${snapshotId}) — aborting before any poke.\n` +
+      `  ${back.detail}\n` +
+      '  A poke now would stall for the node\'s fetch budget on every target and then fail.',
+    )
+  }
+  if (back.state?.signature !== signature) {
+    throw new Error(
+      `Snapshot ${snapshotId} holds a DIFFERENT signed object — aborting before any poke.\n` +
+      `  Revision ${revision} is an immutable slot; it is already taken by another envelope.\n` +
+      '  Publish a new revision, or investigate owner equivocation.',
+    )
+  }
+  log('   confirmed: the node holds our signature')
+
+  // ── 3. head PUT ────────────────────────────────────────────────
+  log(`── 3/4 head PUT       ${headId}`)
+  await node.publish({
+    wasmPath: contracts.paths.object,
+    params: objectParams(ref),
+    state: envelope,
+  })
+  const headBack = await node.get(headId)
+  const headState = headBack.found && headBack.state?.signature === signature
+    ? { confirmed: true, detail: 'the node holds the same signed object' }
+    : {
+        confirmed: false,
+        detail: headBack.found
+          ? `the node kept revision ${headBack.state?.item?.revision ?? '?'}; LWW discarded ours (${revision}). ` +
+            'Bump item.revision past it, re-sign, re-publish.'
+          : `could not read the head back: ${headBack.detail}`,
+      }
+  log(`   head: ${headState.confirmed ? 'confirmed' : `⚠ ${headState.detail}`}`)
+
+  // ── 4. pokes ───────────────────────────────────────────────────
+  const targets = relationTargets(envelope)
+  log(`── 4/4 poking ${targets.length} distinct relation target(s)`)
+
+  const pokes = []
+  for (const target of targets) {
+    try {
+      const { indexId, created } = await pokeTarget({
+        target, sourceRef: ref, revision, node, addressing, contracts, log,
+      })
+      pokes.push({ target, indexId, created, ok: true, error: null })
+      log(`   ✓ ${target}`)
+    } catch (err) {
+      pokes.push({ target, indexId: null, created: false, ok: false, error: err.message })
+      log(`   ✗ ${target}  (${err.message.split('\n')[0]})`)
+    }
+  }
+
+  return {
+    ref,
+    revision,
+    snapshotId,
+    headId,
+    headState,
+    pokes,
+    failed: pokes.filter(p => !p.ok).length,
+  }
+}

--- a/src/freenet/publish.js
+++ b/src/freenet/publish.js
@@ -189,7 +189,7 @@ export async function publishObject({ envelope, node, addressing, contracts, log
 
   const pokes = []
   for (const target of targets) {
-      const tombstone = !currentSet.has(refKey(target))
+    const tombstone = !currentSet.has(refKey(target))
     try {
       const { indexId, created } = await pokeTarget({
         target, sourceRef: ref, revision, node, addressing, contracts, log,

--- a/src/freenet/relations.js
+++ b/src/freenet/relations.js
@@ -63,7 +63,7 @@ export function relationTargets(envelope) {
       }
     }
   }
-  return [...targets.values()].sort()
+  return [...targets.values()].sort(compareUtf8)
 }
 
 /**
@@ -97,7 +97,7 @@ export function relationNamesTargeting(envelope, target) {
       }
     }
   }
-  return [...names].sort().slice(0, MAX_RELATIONS_PER_SLOT)
+  return [...names].sort(compareUtf8).slice(0, MAX_RELATIONS_PER_SLOT)
 }
 
 /**
@@ -108,6 +108,26 @@ export function relationNamesTargeting(envelope, target) {
  * then read as a door-2 artifact for no reason but the encoding.
  */
 const codePoints = (s) => [...s].length
+
+const utf8 = new TextEncoder()
+
+/**
+ * Rust's `String` ordering: lexicographic over UTF-8 BYTES.
+ *
+ * JS's default sort compares UTF-16 code units, and the two disagree above
+ * U+E000 — a non-BMP character is a surrogate pair beginning 0xD800, so JS
+ * sorts it BEFORE U+E000 while Rust (and code-point order) sorts it after.
+ * The contract sorts before it truncates to 64 and before it serializes the
+ * slot, so a different order here means both a mismatched comparison and
+ * potentially a different 64 names surviving.
+ */
+function compareUtf8(a, b) {
+  const x = utf8.encode(a)
+  const y = utf8.encode(b)
+  const n = Math.min(x.length, y.length)
+  for (let i = 0; i < n; i++) if (x[i] !== y[i]) return x[i] - y[i]
+  return x.length - y.length
+}
 
 /** An envelope's ref. */
 export function envelopeRef(envelope) {

--- a/src/freenet/relations.js
+++ b/src/freenet/relations.js
@@ -8,6 +8,8 @@
  * share this module rather than each doing their own walk.
  */
 
+import { canonicalRef } from './addressing.js'
+
 /**
  * Every distinct target ref in `item.relations`, sorted.
  *
@@ -34,23 +36,46 @@ export function relationTargets(envelope) {
 }
 
 /**
- * The relation names under which an envelope points at one target — sorted
- * and unique, which is exactly the shape a verified index slot carries (D2).
+ * D2 slot bounds. These are the contract's own deterministic filters — every
+ * peer must drop exactly the same entries for the merged state to converge —
+ * so a verifier that does not apply them computes an expectation the contract
+ * could never have written, and reports honest slots as door-2 artifacts.
+ */
+const MAX_RELATION_NAME = 128
+const MAX_RELATIONS_PER_SLOT = 64
+
+/**
+ * The relation names under which an envelope points at one target — sorted,
+ * unique, and filtered exactly as the index contract filters them, which is
+ * the shape a verified index slot carries (D2).
  *
  * @param {object} envelope
- * @param {string} target
+ * @param {string} target - compared canonically; see canonicalRef
  * @returns {string[]}
  */
 export function relationNamesTargeting(envelope, target) {
   const relations = envelope?.item?.relations
+  const wanted = canonicalOrNull(target)
   const names = new Set()
   if (relations && typeof relations === 'object') {
     for (const [name, entries] of Object.entries(relations)) {
       if (!Array.isArray(entries)) continue
-      if (entries.some(e => e && e.ref === target)) names.add(name)
+      if (!name || name.length > MAX_RELATION_NAME) continue
+      if (entries.some(e => e && typeof e.ref === 'string' && canonicalOrNull(e.ref) === wanted)) {
+        names.add(name)
+      }
     }
   }
-  return [...names].sort()
+  return [...names].sort().slice(0, MAX_RELATIONS_PER_SLOT)
+}
+
+/** Canonical form of a ref, or the raw string when it cannot be parsed. */
+function canonicalOrNull(ref) {
+  try {
+    return canonicalRef(ref)
+  } catch {
+    return ref
+  }
 }
 
 /** An envelope's ref. */

--- a/src/freenet/relations.js
+++ b/src/freenet/relations.js
@@ -8,7 +8,32 @@
  * share this module rather than each doing their own walk.
  */
 
-import { canonicalRef } from './addressing.js'
+import { objectParams } from './addressing.js'
+
+/**
+ * The identity the index contract uses for a ref.
+ *
+ * The contract does NOT compare ref strings — it compares derived bytes:
+ *
+ *   owner_addr_from_pubkey(pubkey) == target_addr && uuid == target_uuid
+ *
+ * which is exactly the 32-byte object params. Mirroring that (rather than
+ * inventing our own canonical string) means our reading of "same object"
+ * cannot drift from the contract's — including uuid case, which the contract
+ * folds away by parsing the uuid to bytes.
+ *
+ * Unparseable refs key on themselves. The contract skips them entirely
+ * (validate_ref(...).ok()), and since a verification target is always
+ * parseable, a self-keyed junk ref can never match one — same outcome, while
+ * still surviving to be reported by the publish flow.
+ */
+export function relationKey(ref) {
+  try {
+    return [...objectParams(ref)].map(b => b.toString(16).padStart(2, '0')).join('')
+  } catch {
+    return `raw:${ref}`
+  }
+}
 
 /**
  * Every distinct target ref in `item.relations`, sorted.
@@ -33,7 +58,7 @@ export function relationTargets(envelope) {
       if (!Array.isArray(entries)) continue
       for (const entry of entries) {
         if (!entry || typeof entry.ref !== 'string' || !entry.ref) continue
-        const key = canonicalOrNull(entry.ref)
+        const key = relationKey(entry.ref)
         if (!targets.has(key)) targets.set(key, entry.ref)
       }
     }
@@ -47,7 +72,7 @@ export function relationTargets(envelope) {
  * so a verifier that does not apply them computes an expectation the contract
  * could never have written, and reports honest slots as door-2 artifacts.
  */
-const MAX_RELATION_NAME = 128
+const MAX_RELATION_NAME_CHARS = 128
 const MAX_RELATIONS_PER_SLOT = 64
 
 /**
@@ -56,18 +81,18 @@ const MAX_RELATIONS_PER_SLOT = 64
  * the shape a verified index slot carries (D2).
  *
  * @param {object} envelope
- * @param {string} target - compared canonically; see canonicalRef
+ * @param {string} target - compared by derived bytes; see relationKey
  * @returns {string[]}
  */
 export function relationNamesTargeting(envelope, target) {
   const relations = envelope?.item?.relations
-  const wanted = canonicalOrNull(target)
+  const wanted = relationKey(target)
   const names = new Set()
   if (relations && typeof relations === 'object') {
     for (const [name, entries] of Object.entries(relations)) {
       if (!Array.isArray(entries)) continue
-      if (!name || name.length > MAX_RELATION_NAME) continue
-      if (entries.some(e => e && typeof e.ref === 'string' && canonicalOrNull(e.ref) === wanted)) {
+      if (!name || codePoints(name) > MAX_RELATION_NAME_CHARS) continue
+      if (entries.some(e => e && typeof e.ref === 'string' && relationKey(e.ref) === wanted)) {
         names.add(name)
       }
     }
@@ -75,14 +100,14 @@ export function relationNamesTargeting(envelope, target) {
   return [...names].sort().slice(0, MAX_RELATIONS_PER_SLOT)
 }
 
-/** Canonical form of a ref, or the raw string when it cannot be parsed. */
-function canonicalOrNull(ref) {
-  try {
-    return canonicalRef(ref)
-  } catch {
-    return ref
-  }
-}
+/**
+ * Length in Unicode code points — what Rust's `chars().count()` counts.
+ *
+ * JS `.length` counts UTF-16 code units, so a name of 100 emoji measures 200
+ * there. Using it would drop a name the contract kept, and the slot would
+ * then read as a door-2 artifact for no reason but the encoding.
+ */
+const codePoints = (s) => [...s].length
 
 /** An envelope's ref. */
 export function envelopeRef(envelope) {

--- a/src/freenet/relations.js
+++ b/src/freenet/relations.js
@@ -23,16 +23,22 @@ import { canonicalRef } from './addressing.js'
  */
 export function relationTargets(envelope) {
   const relations = envelope?.item?.relations
-  const targets = new Set()
+  // Keyed canonically: two spellings of one ref (uuid case) address the SAME
+  // index contract, so poking both is a wasted round-trip on a flow whose
+  // entire cost is round-trips. Malformed refs key on themselves and survive
+  // to be reported, rather than being silently dropped here.
+  const targets = new Map()
   if (relations && typeof relations === 'object') {
     for (const entries of Object.values(relations)) {
       if (!Array.isArray(entries)) continue
       for (const entry of entries) {
-        if (entry && typeof entry.ref === 'string' && entry.ref) targets.add(entry.ref)
+        if (!entry || typeof entry.ref !== 'string' || !entry.ref) continue
+        const key = canonicalOrNull(entry.ref)
+        if (!targets.has(key)) targets.set(key, entry.ref)
       }
     }
   }
-  return [...targets].sort()
+  return [...targets.values()].sort()
 }
 
 /**

--- a/src/freenet/relations.js
+++ b/src/freenet/relations.js
@@ -1,0 +1,73 @@
+/**
+ * Reading relations out of a signed envelope.
+ *
+ * Both directions of the inbound index depend on agreeing exactly what an
+ * envelope claims: the publisher derives "whose index do I poke", and the
+ * verifier derives "what should that index's slot say about me". If those two
+ * readings ever diverge, every slot verifies as a door-2 artifact — so they
+ * share this module rather than each doing their own walk.
+ */
+
+/**
+ * Every distinct target ref in `item.relations`, sorted.
+ *
+ * Mirrors the reference flow's
+ *   [.item.relations // {} | .[][]? | .ref | select(type == "string")] | unique
+ * — non-array relation values and entries without a string `ref` are ignored
+ * rather than fatal, because an envelope is signed data we do not control.
+ *
+ * @param {object} envelope
+ * @returns {string[]}
+ */
+export function relationTargets(envelope) {
+  const relations = envelope?.item?.relations
+  const targets = new Set()
+  if (relations && typeof relations === 'object') {
+    for (const entries of Object.values(relations)) {
+      if (!Array.isArray(entries)) continue
+      for (const entry of entries) {
+        if (entry && typeof entry.ref === 'string' && entry.ref) targets.add(entry.ref)
+      }
+    }
+  }
+  return [...targets].sort()
+}
+
+/**
+ * The relation names under which an envelope points at one target — sorted
+ * and unique, which is exactly the shape a verified index slot carries (D2).
+ *
+ * @param {object} envelope
+ * @param {string} target
+ * @returns {string[]}
+ */
+export function relationNamesTargeting(envelope, target) {
+  const relations = envelope?.item?.relations
+  const names = new Set()
+  if (relations && typeof relations === 'object') {
+    for (const [name, entries] of Object.entries(relations)) {
+      if (!Array.isArray(entries)) continue
+      if (entries.some(e => e && e.ref === target)) names.add(name)
+    }
+  }
+  return [...names].sort()
+}
+
+/** An envelope's ref. */
+export function envelopeRef(envelope) {
+  const item = envelope?.item
+  if (!item?.pubkey || !item?.id) {
+    throw new Error('Envelope is missing item.pubkey / item.id — not an instructionGraph object')
+  }
+  return `${item.pubkey}.${item.id}`
+}
+
+/** An envelope's revision; absent means 0, matching the contracts' LWW base. */
+export function envelopeRevision(envelope) {
+  const rev = envelope?.item?.revision
+  if (rev === undefined || rev === null) return 0
+  if (!Number.isSafeInteger(rev) || rev < 0) {
+    throw new Error(`Envelope has an invalid item.revision: ${JSON.stringify(rev)}`)
+  }
+  return rev
+}

--- a/src/freenet/verify.js
+++ b/src/freenet/verify.js
@@ -1,0 +1,125 @@
+/**
+ * US-3.4 reader-side verification of an inbound index.
+ *
+ * The index is a FILTER, NOT PROOF: the contract's creation and seeding paths
+ * accept structure-only states ("door 2"), so any single slot is a claim until
+ * checked. This gives a reader certainty without trusting the index, by
+ * re-deriving each slot from the source's own signed snapshot — the ground
+ * truth — and only then asking whether the source has moved on since.
+ *
+ *   verified-current  slot matches its snapshot AND the source's head is
+ *                     still at that revision
+ *   verified-stale    slot matches its snapshot, but the head has moved past
+ *                     it — or the head is not on the node, in which case
+ *                     currency is unknowable and the detail says so (D6)
+ *   unverified        snapshot missing, or its content disagrees with the
+ *                     slot (a door-2 artifact, or a stale WASM build)
+ *
+ * `ok` is true iff no slot is unverified. Stale is an honest, verified state.
+ */
+
+import { relationNamesTargeting, envelopeRevision } from './relations.js'
+import { parseRef } from './addressing.js'
+
+const sameNames = (a, b) => a.length === b.length && a.every((v, i) => v === b[i])
+
+/**
+ * Check one slot against the snapshot it claims to summarize.
+ * Returns a status object; never throws for a bad slot — a broken slot is a
+ * finding, not a crash.
+ */
+async function verifySlot({ source, slot, target, node, addressing }) {
+  try {
+    parseRef(source)
+  } catch (err) {
+    return { source, slot, status: 'unverified', detail: `slot key is not a usable ref — ${err.message}` }
+  }
+
+  const slotRevision = slot?.revision
+  if (!Number.isSafeInteger(slotRevision) || slotRevision < 0) {
+    return { source, slot, status: 'unverified', detail: `slot has an invalid revision: ${JSON.stringify(slotRevision)}` }
+  }
+
+  // 1. The snapshot is the ground truth for this slot.
+  const snapshotId = addressing.snapshotId(source, slotRevision)
+  const snap = await node.get(snapshotId)
+  if (!snap.found) {
+    return {
+      source, slot, snapshotId, status: 'unverified',
+      detail: `snapshot for revision ${slotRevision} is not on the node (${snapshotId})` +
+        (snap.timedOut ? ' — the GET timed out, so this may be a slow fetch rather than an absence' : ''),
+    }
+  }
+
+  // 2. Recompute what the slot SHOULD say: the snapshot's own revision, and
+  //    the sorted relation names under which it points at us. Only these two
+  //    fields are compared — they are the whole of a slot (D2), and the state
+  //    schema is deny_unknown_fields, so there is nothing else to disagree on.
+  const expectedRelations = relationNamesTargeting(snap.state, target)
+  const snapshotRevision = envelopeRevision(snap.state)
+  const claimed = Array.isArray(slot.relations) ? slot.relations : null
+
+  if (snapshotRevision !== slotRevision) {
+    return {
+      source, slot, snapshotId, status: 'unverified',
+      detail: `snapshot disagrees with the slot: it carries revision ${snapshotRevision}, the slot claims ${slotRevision}`,
+    }
+  }
+  if (!claimed || !sameNames(claimed, expectedRelations)) {
+    return {
+      source, slot, snapshotId, status: 'unverified',
+      detail: `snapshot disagrees with the slot: expected relations [${expectedRelations.join(', ')}], ` +
+        `slot claims [${(claimed ?? []).join(', ')}] — a door-2 artifact, or a stale WASM build`,
+    }
+  }
+
+  // 3. Currency: is the source's head still at this revision?
+  const headId = addressing.headId(source)
+  const head = await node.get(headId)
+  if (!head.found) {
+    return {
+      source, slot, snapshotId, headId, status: 'verified-stale',
+      detail: 'head not on node — currency unknown',
+    }
+  }
+  const headRevision = envelopeRevision(head.state)
+  return headRevision === slotRevision
+    ? { source, slot, snapshotId, headId, status: 'verified-current', detail: '' }
+    : { source, slot, snapshotId, headId, status: 'verified-stale', detail: `head is at ${headRevision}` }
+}
+
+/**
+ * @param {object} opts
+ * @param {string} opts.ref - the index target
+ * @param {object} opts.node
+ * @param {object} opts.addressing
+ * @param {(msg: string) => void} [opts.log]
+ * @returns {Promise<{ref, indexId, slots: object[], unverified: number, ok: boolean}>}
+ */
+export async function verifyIndex({ ref, node, addressing, log = () => {} }) {
+  parseRef(ref)
+  const indexId = addressing.indexId(ref)
+
+  const index = await node.get(indexId)
+  if (!index.found) {
+    throw new Error(
+      `No inbound index on the node for ${ref} (${indexId}).\n` +
+      `  ${index.detail}\n` +
+      '  No publish flow has poked this target yet — this is different from an index with no slots.',
+    )
+  }
+
+  const slotMap = index.state?.slots ?? {}
+  const entries = Object.entries(slotMap)
+  log(`── verifying ${entries.length} slot(s) of the inbound index of ${ref}`)
+
+  const slots = []
+  for (const [source, slot] of entries) {
+    const result = await verifySlot({ source, slot, target: ref, node, addressing })
+    slots.push(result)
+    log(`${result.status.padEnd(17)} ${source} @ ${slot?.revision}${result.detail ? `  (${result.detail})` : ''}`)
+  }
+
+  const unverified = slots.filter(s => s.status === 'unverified').length
+  return { ref, indexId, slots, unverified, ok: unverified === 0 }
+}

--- a/src/freenet/verify.js
+++ b/src/freenet/verify.js
@@ -89,14 +89,32 @@ async function verifySlot({ source, slot, target, node, addressing }) {
 }
 
 /**
+ * One slot's human-readable line. Lives here, next to the statuses it
+ * renders, so there is a single formatter — the caller chooses the stream,
+ * never the wording.
+ *
+ * @param {object} result - an entry of the report's `slots`
+ * @returns {string}
+ */
+export function formatSlot(result) {
+  return `${result.status.padEnd(17)} ${result.source} @ ${result.slot?.revision}` +
+    (result.detail ? `  (${result.detail})` : '')
+}
+
+/**
  * @param {object} opts
  * @param {string} opts.ref - the index target
  * @param {object} opts.node
  * @param {object} opts.addressing
- * @param {(msg: string) => void} [opts.log]
+ * @param {(msg: string) => void} [opts.log] - headline progress
+ * @param {(result: object) => void} [opts.onSlot] - called as each slot
+ *   resolves, so a caller can stream results while the rest are still being
+ *   fetched. Verification does NOT print slots itself: whether a slot line is
+ *   payload (stdout) or progress (stderr) is the caller's decision, and
+ *   deciding here is what made it get printed twice.
  * @returns {Promise<{ref, indexId, slots: object[], unverified: number, ok: boolean}>}
  */
-export async function verifyIndex({ ref, node, addressing, log = () => {} }) {
+export async function verifyIndex({ ref, node, addressing, log = () => {}, onSlot = () => {} }) {
   parseRef(ref)
   const indexId = addressing.indexId(ref)
 
@@ -117,7 +135,7 @@ export async function verifyIndex({ ref, node, addressing, log = () => {} }) {
   for (const [source, slot] of entries) {
     const result = await verifySlot({ source, slot, target: ref, node, addressing })
     slots.push(result)
-    log(`${result.status.padEnd(17)} ${source} @ ${slot?.revision}${result.detail ? `  (${result.detail})` : ''}`)
+    onSlot(result)
   }
 
   const unverified = slots.filter(s => s.status === 'unverified').length

--- a/test-support/fake-fdev.js
+++ b/test-support/fake-fdev.js
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+/**
+ * Test-support: a stand-in for the `fdev` binary, so the CLI's whole flow can
+ * be exercised offline — no Freenet node, no network, no shared node touched.
+ *
+ * Behaviour is driven by a JSON state file named in FAKE_FDEV_STATE:
+ *
+ *   {
+ *     "contracts":   { "<contract-id>": <state> },   // what the node holds
+ *     "failUpdate":  ["<contract-id>", ...],         // pokes that get rejected
+ *     "failPublish": ["<wasm basename>", ...],       // PUTs that fail
+ *     "swallowPublish": ["<wasm basename>", ...],    // PUTs accepted, state
+ *                                                    //   never stored — the
+ *                                                    //   real "placement did
+ *                                                    //   not stick" failure
+ *     "hang":        ["<contract-id>", ...],         // GETs that never answer
+ *     "calls":       []                              // appended, for assertions
+ *   }
+ *
+ * PUTs are stored under the id they address, so a publish followed by the
+ * flow's GET-back gate behaves like a real node. Deriving that id uses this
+ * repo's own addressing module: the fixture is therefore NOT independent
+ * evidence that ids are correct — the golden-vector unit tests and the live
+ * e2e cover that. What this fixture is evidence for is flow orchestration:
+ * call order, the DEV-2 probe/create/poke arms, per-target reporting, output
+ * formatting and exit codes.
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs'
+import { basename } from 'node:path'
+import { contractId } from '../src/freenet/addressing.js'
+import { blake3 } from '../src/freenet/blake3.js'
+
+const statePath = process.env.FAKE_FDEV_STATE
+if (!statePath) {
+  process.stderr.write('fake-fdev: FAKE_FDEV_STATE is not set\n')
+  process.exit(2)
+}
+
+const state = JSON.parse(readFileSync(statePath, 'utf-8'))
+state.calls ??= []
+state.contracts ??= {}
+
+const argv = process.argv.slice(2)
+const valueOf = (name) => {
+  const i = argv.indexOf(name)
+  return i === -1 ? null : argv[i + 1]
+}
+
+const save = () => writeFileSync(statePath, JSON.stringify(state, null, 2))
+const fail = (msg, code = 1) => {
+  save()
+  process.stderr.write(`[31mError: ${msg}[0m\n`)
+  process.exit(code)
+}
+
+const idFor = (wasmPath, paramsPath) =>
+  contractId(blake3(new Uint8Array(readFileSync(wasmPath))), new Uint8Array(readFileSync(paramsPath)))
+
+// `fdev -p PORT execute get <ID> --output F --timeout S`
+if (argv[2] === 'execute' && argv[3] === 'get') {
+  const id = argv[4]
+  state.calls.push({ op: 'get', id, timeout: valueOf('--timeout') })
+  if (state.hang?.includes(id)) {
+    save()
+    // Outlive any timeout the caller set, so the caller's bound is what fires.
+    setTimeout(() => process.exit(0), 10 * 60_000)
+  } else if (!(id in state.contracts)) {
+    fail(`contract not found: ${id}`)
+  } else {
+    writeFileSync(valueOf('--output'), JSON.stringify(state.contracts[id]))
+    save()
+    process.exit(0)
+  }
+}
+
+// `fdev -p PORT execute update <ID> <DELTA> --timeout S`
+else if (argv[2] === 'execute' && argv[3] === 'update') {
+  const id = argv[4]
+  const payload = JSON.parse(readFileSync(argv[5], 'utf-8'))
+  state.calls.push({ op: 'update', id, payload })
+  if (state.failUpdate?.includes(id)) fail(`InvalidUpdateWithInfo: contract rejected the poke for ${id}`)
+  save()
+  process.exit(0)
+}
+
+// `fdev -p PORT publish --code W --parameters P --timeout S contract --state S`
+else if (argv[2] === 'publish') {
+  const wasmPath = valueOf('--code')
+  const id = idFor(wasmPath, valueOf('--parameters'))
+  const published = JSON.parse(readFileSync(valueOf('--state'), 'utf-8'))
+  state.calls.push({ op: 'publish', id, wasm: basename(wasmPath) })
+  if (state.failPublish?.includes(basename(wasmPath))) fail('put timed out after 1 peer attempt(s)')
+  // A real node's merge is LWW; first write wins here unless it is an index
+  // being (re)created, which unions — close enough for flow assertions.
+  if (!state.swallowPublish?.includes(basename(wasmPath))) state.contracts[id] ??= published
+  save()
+  process.stdout.write(`response_key: ${id}\n`)
+  process.exit(0)
+}
+
+else fail(`fake-fdev: unsupported invocation: ${argv.join(' ')}`, 2)

--- a/test/freenet-addressing.test.js
+++ b/test/freenet-addressing.test.js
@@ -1,0 +1,124 @@
+/**
+ * Freenet contract addressing.
+ *
+ * Golden vectors are LIVE-VERIFIED ids — the contracts these params address
+ * were actually published to a Freenet node during the inbound-index spike
+ * (2026-06-11, spikes/inbound-index/NOTES.md), and the same ids are what
+ * `fdev execute get-contract-id` derives. So these assertions pin our
+ * derivation to the real keyspace, not to our own arithmetic.
+ *
+ * The three code hashes are BLAKE3 of the pinned contract WASMs; they are
+ * inlined here so the unit tests need no build artifacts on disk. The e2e
+ * test re-derives them from the actual .wasm files and asserts they match.
+ */
+
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  createAddressing, parseRef, objectParams, snapshotParams, contractId,
+} from '../src/freenet/addressing.js'
+
+const toHex = (bytes) => [...bytes].map(b => b.toString(16).padStart(2, '0')).join('')
+const fromHex = (hex) => Uint8Array.from(hex.match(/../g).map(h => parseInt(h, 16)))
+
+const CODE_HASHES = {
+  object: fromHex('6631a15614c55e96d5297c459461bbb63ec47fd7a4fa6050e2cf104815ed3ff0'),
+  snapshot: fromHex('f2e5cf0d8f7ddd588fd2edd782e224bb146593ec0910b8d1dd0635e161c92c44'),
+  index: fromHex('27d3ea150dd78b093b0afcc2b62b43147690a2da1b0e9f5e3ea71c8b4a6c6568'),
+}
+
+const TIJS = 'ApWJVWXvVKIIMnH6CP6u8HUyU2gLvyYGnwRlgrWAUwcP.00000000-0000-0000-0000-000000000001'
+const ROOT = 'AxyU5_5vWmP2tO_klN4UpbZzRsuJEvJTrdwdg_gODxZJ.00000000-0000-0000-0000-000000000000'
+
+const addressing = () => createAddressing(CODE_HASHES)
+
+test('parseRef splits <pubkey>.<uuid> and rejects malformed refs', () => {
+  assert.deepEqual(parseRef(TIJS), {
+    pubkey: 'ApWJVWXvVKIIMnH6CP6u8HUyU2gLvyYGnwRlgrWAUwcP',
+    uuid: '00000000-0000-0000-0000-000000000001',
+  })
+  for (const bad of ['', 'nodot', 'ApWJ.', '.uuid', 'ApWJVWXvVKIIMnH6CP6u8HUyU2gLvyYGnwRlgrWAUwcP.not-a-uuid']) {
+    assert.throws(() => parseRef(bad), /ref/i, `should reject: ${JSON.stringify(bad)}`)
+  }
+})
+
+test('parseRef rejects a pubkey that is not a 33-byte compressed point', () => {
+  assert.throws(() => parseRef('AAAA.00000000-0000-0000-0000-000000000001'), /pubkey/i)
+})
+
+test('objectParams is blake3(pubkey_raw)[..16] ‖ uuid_16, matching derive-params', () => {
+  const p = objectParams(TIJS)
+  assert.equal(p.length, 32)
+  // owner_addr printed by the Rust derive-params tool for this identity.
+  assert.equal(toHex(p), '94296828df5ad8740d45310680ee3c9a00000000000000000000000000000001')
+})
+
+test('snapshotParams appends the revision as big-endian u64', () => {
+  const p = snapshotParams(TIJS, 3)
+  assert.equal(p.length, 40)
+  assert.equal(
+    toHex(p),
+    '94296828df5ad8740d45310680ee3c9a000000000000000000000000000000010000000000000003',
+  )
+  assert.equal(toHex(snapshotParams(TIJS, 0)).slice(64), '0000000000000000')
+  // Above 2^32 the high half must carry — a naive 32-bit write would lose this.
+  assert.equal(toHex(snapshotParams(TIJS, 0x1_0000_0001)).slice(64), '0000000100000001')
+})
+
+test('snapshotParams rejects revisions that are not safe non-negative integers', () => {
+  for (const bad of [-1, 1.5, NaN, Number.MAX_SAFE_INTEGER + 2, '3', null, undefined]) {
+    assert.throws(() => snapshotParams(TIJS, bad), /revision/i, `should reject: ${bad}`)
+  }
+})
+
+test('contractId is base58(blake3(code_hash ‖ params)) — live-verified golden ids', () => {
+  assert.equal(
+    contractId(CODE_HASHES.snapshot, snapshotParams(TIJS, 3)),
+    '7GHNZLEQToEYz7Z6Jy6e7JqsSKNB4jgxUru1CwjnucbY',
+  )
+  assert.equal(
+    contractId(CODE_HASHES.object, objectParams(TIJS)),
+    'DWzw99Gtxyhu1gDjNKJcVfSsfw9HmEjNLwUrHmxY4VWB',
+  )
+  assert.equal(
+    contractId(CODE_HASHES.index, objectParams(TIJS)),
+    'FQ6Qbh6Y9N2syWVciUNtJoeEL28wCq1UNzRDfUJGNKTp',
+  )
+})
+
+test('createAddressing binds the code hashes and derives all three ids', () => {
+  const a = addressing()
+  assert.equal(a.snapshotId(TIJS, 3), '7GHNZLEQToEYz7Z6Jy6e7JqsSKNB4jgxUru1CwjnucbY')
+  assert.equal(a.headId(TIJS), 'DWzw99Gtxyhu1gDjNKJcVfSsfw9HmEjNLwUrHmxY4VWB')
+  assert.equal(a.indexId(TIJS), 'FQ6Qbh6Y9N2syWVciUNtJoeEL28wCq1UNzRDfUJGNKTp')
+  assert.equal(a.snapshotId(ROOT, 41), 'ExUAkBcvqWMicnkDwPCn6zf6wxAXU2Nc6Ee6Lbpyzpc8')
+})
+
+test('the index lives in its own keyspace but on the TARGET\'s 32-byte params', () => {
+  const a = addressing()
+  // Same params, different WASM → different id. This is what keeps head and
+  // index from colliding even though both are addressed by the bare ref.
+  assert.notEqual(a.indexId(TIJS), a.headId(TIJS))
+  assert.equal(toHex(objectParams(TIJS)).length, 64, 'index params stay 32 bytes')
+})
+
+test('each revision gets its own immutable snapshot address', () => {
+  const a = addressing()
+  const ids = new Set([0, 1, 2, 3, 41].map(r => a.snapshotId(TIJS, r)))
+  assert.equal(ids.size, 5)
+})
+
+test('uuid case does not split an object across two addresses', () => {
+  const [pubkey, uuid] = TIJS.split('.')
+  const upper = `${pubkey}.${uuid.toUpperCase()}`
+  assert.equal(toHex(objectParams(upper)), toHex(objectParams(TIJS)))
+})
+
+test('createAddressing validates the code hashes it is handed', () => {
+  assert.throws(() => createAddressing({}), /code hash/i)
+  assert.throws(
+    () => createAddressing({ ...CODE_HASHES, index: new Uint8Array(31) }),
+    /code hash/i,
+  )
+})

--- a/test/freenet-cli.test.js
+++ b/test/freenet-cli.test.js
@@ -1,0 +1,377 @@
+/**
+ * `ig freenet` CLI integration, end to end, offline.
+ *
+ * Runs the real CLI against a real local .instructionGraph store and a fake
+ * fdev (test-support/fake-fdev.js). No Freenet node is contacted and the
+ * shared node on :7509 is never touched — the fake is selected with --fdev.
+ *
+ * What is under test here is the CLI contract: subcommand surface, flag
+ * handling, what lands on stdout vs stderr, and exit codes. Address
+ * correctness is pinned by the golden vectors in freenet-addressing.test.js
+ * and by the live e2e.
+ */
+
+import { describe, it, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { execFile as execFileCb } from 'node:child_process'
+import { promisify } from 'node:util'
+import { mkdtemp, writeFile, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { setupIgStore } from '../test-support/ig-store.js'
+import { createAddressing } from '../src/freenet/addressing.js'
+import { loadContracts } from '../src/freenet/contracts.js'
+
+const execFile = promisify(execFileCb)
+const CLI = join(import.meta.dirname, '..', 'cli', 'ig.js')
+const FAKE_FDEV = join(import.meta.dirname, '..', 'test-support', 'fake-fdev.js')
+
+describe('ig freenet', () => {
+  let store, contractsDir, fdevShim, statePath, addressing, sourceRef, targetRef, sourceEnv, pokeTargets
+
+  /** Run the CLI; resolves with {stdout, stderr, code} instead of throwing. */
+  async function ig(args, { state = null } = {}) {
+    if (state) await writeFile(statePath, JSON.stringify(state, null, 2))
+    try {
+      const r = await execFile(process.execPath, [CLI, ...args], {
+        env: { ...process.env, INSTRUCTIONGRAPH_DIR: store.dir, FAKE_FDEV_STATE: statePath },
+      })
+      return { ...r, code: 0 }
+    } catch (err) {
+      return { stdout: err.stdout ?? '', stderr: err.stderr ?? '', code: err.code ?? 1 }
+    }
+  }
+
+  /**
+   * Run `ig freenet …` against the fake node. A trailing object is the fake
+   * node's seed state, not an argument. The state is ALWAYS rewritten, so each
+   * invocation starts from a known node rather than inheriting the last test's.
+   */
+  const fn = (...args) => {
+    const last = args.at(-1)
+    const seed = last !== null && typeof last === 'object' ? args.pop() : {}
+    return ig(['freenet', ...args, '--contracts-dir', contractsDir, '--fdev', fdevShim], { state: seed })
+  }
+
+  const readState = async () => JSON.parse(await readFile(statePath, 'utf-8'))
+
+  /** `ig create` prints a status line before the ref; the ref is last. */
+  const lastLine = (stdout) => stdout.trim().split('\n').pop().trim()
+
+  before(async () => {
+    store = await setupIgStore({ realm: 'server-public' })
+
+    // Stand-in contract WASMs: distinct bytes are all the addressing needs.
+    contractsDir = await mkdtemp(join(tmpdir(), 'ig-fn-wasm-'))
+    await writeFile(join(contractsDir, 'dataverse_object.wasm'), 'fake-object-contract')
+    await writeFile(join(contractsDir, 'dataverse_object_rev.wasm'), 'fake-snapshot-contract')
+    await writeFile(join(contractsDir, 'dataverse_inbound_index.wasm'), 'fake-index-contract')
+    addressing = createAddressing(loadContracts(contractsDir).codeHashes)
+
+    const bin = await mkdtemp(join(tmpdir(), 'ig-fn-bin-'))
+    fdevShim = join(bin, 'fdev')
+    await writeFile(fdevShim, `#!/bin/sh\nexec ${process.execPath} ${JSON.stringify(FAKE_FDEV)} "$@"\n`, { mode: 0o755 })
+
+    statePath = join(await mkdtemp(join(tmpdir(), 'ig-fn-state-')), 'state.json')
+    await writeFile(statePath, '{}')
+
+    // A real signed target, and a real signed source pointing at it twice.
+    const specPath = join(contractsDir, 'spec.json')
+    await writeFile(specPath, JSON.stringify({ type: 'NOTE', name: 'target', instruction: 'target object' }))
+    targetRef = lastLine((await ig(['create', specPath, '--no-push'])).stdout)
+
+    await writeFile(specPath, JSON.stringify({
+      type: 'NOTE',
+      name: 'source',
+      instruction: 'source object',
+      relations: { root: [{ ref: targetRef }], mentions: [{ ref: targetRef }] },
+    }))
+    sourceRef = lastLine((await ig(['create', specPath, '--no-push'])).stdout)
+    sourceEnv = JSON.parse((await ig(['get', sourceRef])).stdout)
+
+    // `ig create` also auto-fills relations.author → the signer's identity
+    // object, so the real target set is {target, author} — two distinct
+    // targets reached by three relations.
+    pokeTargets = [...new Set(
+      Object.values(sourceEnv.item.relations).flat().map(entry => entry.ref),
+    )]
+    assert.equal(pokeTargets.length, 2)
+    assert.ok(pokeTargets.includes(targetRef))
+  })
+
+  after(async () => {
+    for (const d of [store?.dir, contractsDir]) if (d) await rm(d, { recursive: true, force: true })
+  })
+
+  // ─── surface ───────────────────────────────────────────────────
+
+  it('lists its subcommands in --help', async () => {
+    const { stdout, code } = await ig(['freenet', '--help'])
+    assert.equal(code, 0)
+    for (const sub of ['publish', 'get', 'inbound', 'verify', 'derive', 'config']) {
+      assert.match(stdout, new RegExp(`ig freenet ${sub}`), `--help should document '${sub}'`)
+    }
+  })
+
+  it('rejects an unknown subcommand and an unknown flag', async () => {
+    const bad = await ig(['freenet', 'frobnicate'])
+    assert.equal(bad.code, 1)
+    assert.match(bad.stderr, /frobnicate/)
+
+    const badFlag = await fn('derive', sourceRef, '--nope', 'x')
+    assert.equal(badFlag.code, 1)
+    assert.match(badFlag.stderr, /--nope/)
+  })
+
+  // ─── config ────────────────────────────────────────────────────
+
+  it('explains what to configure when the contracts dir is unset', async () => {
+    const { stderr, code } = await ig(['freenet', 'derive', sourceRef])
+    assert.equal(code, 1)
+    assert.match(stderr, /contracts/i)
+    assert.match(stderr, /freenet-contracts-dir/)
+    assert.match(stderr, /--contracts-dir/)
+  })
+
+  it('stores and shows configuration', async () => {
+    assert.equal((await ig(['freenet', 'config', 'freenet-port', '7511'])).code, 0)
+    const shown = await ig(['freenet', 'config'])
+    assert.match(shown.stdout, /freenet-port\s+7511/)
+    // A stored port is used when no flag overrides it.
+    const derived = await fn('derive', sourceRef)
+    assert.equal(derived.code, 0)
+    assert.equal((await ig(['freenet', 'config', 'freenet-port', '7509'])).code, 0)
+  })
+
+  it('refuses an unknown config key rather than writing it', async () => {
+    const { code, stderr } = await ig(['freenet', 'config', 'freenet-nonsense', 'x'])
+    assert.equal(code, 1)
+    assert.match(stderr, /freenet-nonsense/)
+  })
+
+  // ─── derive ────────────────────────────────────────────────────
+
+  it('derives ids without contacting the node', async () => {
+    const { stdout, code } = await fn('derive', sourceRef, '--rev', '0')
+    assert.equal(code, 0)
+    const out = JSON.parse(stdout)
+    assert.equal(out.head, addressing.headId(sourceRef))
+    assert.equal(out.index, addressing.indexId(sourceRef))
+    assert.equal(out.snapshot, addressing.snapshotId(sourceRef, 0))
+    assert.deepEqual((await readState()).calls ?? [], [], 'derive must not call fdev')
+  })
+
+  it('omits the snapshot id when no revision is given', async () => {
+    const out = JSON.parse((await fn('derive', sourceRef)).stdout)
+    assert.equal(out.snapshot, undefined)
+    assert.ok(out.head && out.index)
+  })
+
+  it('reports a malformed ref instead of deriving a plausible address', async () => {
+    const { code, stderr } = await fn('derive', 'not-a-ref')
+    assert.equal(code, 1)
+    assert.match(stderr, /ref/i)
+  })
+
+  // ─── publish ───────────────────────────────────────────────────
+
+  it('publishes the snapshot, head and index, then pokes each target once', async () => {
+    const { code, stderr } = await fn('publish', sourceRef)
+    assert.equal(code, 0, stderr)
+
+    const { calls } = await readState()
+    const ops = calls.map(c => c.op)
+    assert.equal(ops[0], 'publish')
+    assert.equal(calls[0].wasm, 'dataverse_object_rev.wasm', 'snapshot PUT first')
+    assert.equal(calls[0].id, addressing.snapshotId(sourceRef, 0))
+    assert.equal(ops[1], 'get', 'GET-back gate')
+
+    const pokes = calls.filter(c => c.op === 'update')
+    assert.equal(pokes.length, pokeTargets.length)
+    assert.deepEqual(
+      new Set(pokes.map(p => p.id)),
+      new Set(pokeTargets.map(t => addressing.indexId(t))),
+    )
+    // `root` and `mentions` both point at the target — still exactly one poke.
+    const toTarget = pokes.filter(p => p.id === addressing.indexId(targetRef))
+    assert.equal(toTarget.length, 1)
+    assert.deepEqual(toTarget[0].payload, { v: 1, poke: { source_ref: sourceRef, revision: 0 } })
+
+    assert.match(stderr, /1\/4/)
+    assert.match(stderr, /4\/4/)
+    assert.match(stderr, new RegExp(`${pokeTargets.length}/${pokeTargets.length} ok`))
+  })
+
+  it('is idempotent — a second publish converges and stays exit 0', async () => {
+    const contracts = {
+      [addressing.snapshotId(sourceRef, 0)]: sourceEnv,
+      [addressing.headId(sourceRef)]: sourceEnv,
+    }
+    for (const t of pokeTargets) contracts[addressing.indexId(t)] = { v: 1, slots: {} }
+
+    const { code } = await fn('publish', sourceRef, { contracts })
+    assert.equal(code, 0)
+    const { calls } = await readState()
+    // DEV-2: every index is already local, so none may be re-published.
+    assert.equal(calls.filter(c => c.wasm === 'dataverse_inbound_index.wasm').length, 0)
+    assert.equal(calls.filter(c => c.op === 'update').length, pokeTargets.length)
+  })
+
+  it('aborts before any poke when the snapshot does not GET back', async () => {
+    // The PUT is accepted but the state never sticks — the real "ring
+    // placement did not take" failure. Poking now would stall on every
+    // target for the node's fetch budget and then fail.
+    const { code, stderr } = await fn('publish', sourceRef, {
+      swallowPublish: ['dataverse_object_rev.wasm'],
+    })
+    assert.equal(code, 1)
+    assert.match(stderr, /snapshot did not GET back/i)
+    assert.match(stderr, /poke/i)
+    const { calls } = await readState()
+    assert.equal(calls.filter(c => c.op === 'update').length, 0, 'no poke was sent')
+    assert.equal(
+      calls.filter(c => c.wasm === 'dataverse_object.wasm').length, 0,
+      'the head was never published either',
+    )
+  })
+
+  it('aborts when the snapshot PUT itself fails', async () => {
+    const { code, stderr } = await fn('publish', sourceRef, {
+      failPublish: ['dataverse_object_rev.wasm'],
+    })
+    assert.equal(code, 1)
+    assert.match(stderr, /put timed out/i)
+    const { calls } = await readState()
+    assert.equal(calls.filter(c => c.op === 'update').length, 0)
+  })
+
+  it('exits non-zero and reports the target when a poke fails', async () => {
+    const { code, stderr } = await fn('publish', sourceRef, {
+      failUpdate: [addressing.indexId(targetRef)],
+    })
+    assert.equal(code, 1)
+    // One of the two targets failed; the other still went out.
+    assert.match(stderr, new RegExp(`1/${pokeTargets.length} ok`))
+    assert.match(stderr, new RegExp(targetRef.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')))
+    assert.match(stderr, /InvalidUpdateWithInfo/)
+    assert.match(stderr, /re-run/i, 'tells the user the flow is re-runnable')
+  })
+
+  it('reports a ref that is in neither the local store nor the hub', async () => {
+    const missing = `${store.pubkey}.11111111-1111-4111-8111-111111111111`
+    const { code, stderr } = await fn('publish', missing)
+    assert.equal(code, 1)
+    assert.match(stderr, /not found/i)
+  })
+
+  it('names the fdev path when the binary cannot be run', async () => {
+    const { code, stderr } = await ig([
+      'freenet', 'get', sourceRef, '--contracts-dir', contractsDir, '--fdev', '/no/such/fdev',
+    ])
+    assert.equal(code, 1)
+    assert.match(stderr, /\/no\/such\/fdev/)
+    assert.match(stderr, /fdev/)
+  })
+
+  // ─── get ───────────────────────────────────────────────────────
+
+  it('gets the head and prints the envelope as JSON', async () => {
+    const { stdout, code } = await fn('get', sourceRef, {
+      contracts: { [addressing.headId(sourceRef)]: sourceEnv },
+    })
+    assert.equal(code, 0)
+    assert.deepEqual(JSON.parse(stdout), sourceEnv)
+  })
+
+  it('gets a specific revision with --rev', async () => {
+    const { stdout, code } = await fn('get', sourceRef, '--rev', '0', {
+      contracts: { [addressing.snapshotId(sourceRef, 0)]: sourceEnv },
+    })
+    assert.equal(code, 0)
+    assert.deepEqual(JSON.parse(stdout), sourceEnv)
+  })
+
+  it('never falls back to the head when a revision is missing — absence is meaningful', async () => {
+    const { code, stderr, stdout } = await fn('get', sourceRef, '--rev', '9', {
+      contracts: { [addressing.headId(sourceRef)]: sourceEnv },
+    })
+    assert.equal(code, 1)
+    assert.equal(stdout.trim(), '')
+    assert.match(stderr, /not found|revision 9/i)
+  })
+
+  // ─── inbound ───────────────────────────────────────────────────
+
+  it('prints the slot map as jq-friendly JSON', async () => {
+    const slots = { [sourceRef]: { revision: 0, relations: ['mentions', 'root'] } }
+    const { stdout, code } = await fn('inbound', targetRef, {
+      contracts: { [addressing.indexId(targetRef)]: { v: 1, slots } },
+    })
+    assert.equal(code, 0)
+    assert.deepEqual(JSON.parse(stdout), slots)
+  })
+
+  it('distinguishes an index with no slots from one that does not exist', async () => {
+    const empty = await fn('inbound', targetRef, {
+      contracts: { [addressing.indexId(targetRef)]: { v: 1, slots: {} } },
+    })
+    assert.equal(empty.code, 0)
+    assert.deepEqual(JSON.parse(empty.stdout), {})
+
+    const absent = await fn('inbound', targetRef, { contracts: {} })
+    assert.equal(absent.code, 1)
+    assert.match(absent.stderr, /poked|not exist/i)
+  })
+
+  // ─── verify ────────────────────────────────────────────────────
+
+  it('reports verified-current and exits 0 when every slot checks out', async () => {
+    const { stdout, code } = await fn('verify', targetRef, {
+      contracts: {
+        [addressing.indexId(targetRef)]: {
+          v: 1,
+          slots: { [sourceRef]: { revision: 0, relations: ['mentions', 'root'] } },
+        },
+        [addressing.snapshotId(sourceRef, 0)]: sourceEnv,
+        [addressing.headId(sourceRef)]: sourceEnv,
+      },
+    })
+    assert.equal(code, 0)
+    assert.match(stdout, /verified-current/)
+    assert.match(stdout, new RegExp(sourceRef.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')))
+  })
+
+  it('exits 1 when a slot cannot be verified against its snapshot', async () => {
+    const { stdout, code } = await fn('verify', targetRef, {
+      contracts: {
+        [addressing.indexId(targetRef)]: {
+          v: 1,
+          slots: { [sourceRef]: { revision: 0, relations: ['author'] } },
+        },
+        [addressing.snapshotId(sourceRef, 0)]: sourceEnv,
+        [addressing.headId(sourceRef)]: sourceEnv,
+      },
+    })
+    assert.equal(code, 1)
+    assert.match(stdout, /unverified/)
+  })
+
+  it('exits 0 for a stale-but-honest slot', async () => {
+    const moved = JSON.parse(JSON.stringify(sourceEnv))
+    moved.item.revision = 5
+    const { stdout, code } = await fn('verify', targetRef, {
+      contracts: {
+        [addressing.indexId(targetRef)]: {
+          v: 1,
+          slots: { [sourceRef]: { revision: 0, relations: ['mentions', 'root'] } },
+        },
+        [addressing.snapshotId(sourceRef, 0)]: sourceEnv,
+        [addressing.headId(sourceRef)]: moved,
+      },
+    })
+    assert.equal(code, 0)
+    assert.match(stdout, /verified-stale/)
+    assert.match(stdout, /head is at 5/)
+  })
+})

--- a/test/freenet-cli.test.js
+++ b/test/freenet-cli.test.js
@@ -374,4 +374,43 @@ describe('ig freenet', () => {
     assert.match(stdout, /verified-stale/)
     assert.match(stdout, /head is at 5/)
   })
+
+  // ─── output discipline ─────────────────────────────────────────
+
+  it('verify prints each slot exactly once, on stdout', async () => {
+    const seeded = {
+      contracts: {
+        [addressing.indexId(targetRef)]: {
+          v: 1,
+          slots: { [sourceRef]: { revision: 0, relations: ['mentions', 'root'] } },
+        },
+        [addressing.snapshotId(sourceRef, 0)]: sourceEnv,
+        [addressing.headId(sourceRef)]: sourceEnv,
+      },
+    }
+    const { stdout, stderr, code } = await fn('verify', targetRef, seeded)
+    assert.equal(code, 0)
+
+    const count = (text) => text.split('\n').filter(l => l.includes('verified-current')).length
+    assert.equal(count(stdout), 1, 'the slot line belongs on stdout')
+    assert.equal(count(stderr), 0, 'and must not be repeated as stderr progress')
+  })
+
+  it('verify --json keeps stdout pure JSON and streams progress to stderr', async () => {
+    const seeded = {
+      contracts: {
+        [addressing.indexId(targetRef)]: {
+          v: 1,
+          slots: { [sourceRef]: { revision: 0, relations: ['mentions', 'root'] } },
+        },
+        [addressing.snapshotId(sourceRef, 0)]: sourceEnv,
+        [addressing.headId(sourceRef)]: sourceEnv,
+      },
+    }
+    const { stdout, stderr, code } = await fn('verify', targetRef, '--json', seeded)
+    assert.equal(code, 0)
+    const report = JSON.parse(stdout) // throws if anything else leaked to stdout
+    assert.equal(report.slots[0].status, 'verified-current')
+    assert.match(stderr, /verified-current/, 'progress still streams while it works')
+  })
 })

--- a/test/freenet-e2e.test.js
+++ b/test/freenet-e2e.test.js
@@ -184,6 +184,41 @@ describe('freenet e2e — live node', { skip: noNode }, () => {
     assert.match(stderr, /not found|revision 9999/i)
   })
 
+  it('US-2.4: dropping a relation tombstones the slot in the dropped target', async () => {
+    // A second target, linked at this revision and dropped at the next.
+    const spec = join(store.dir, 'drop.json')
+    writeFileSync(spec, JSON.stringify({ type: 'NOTE', name: 'e2e drop target', instruction: 'dropped' }))
+    const dropRef = lastLine((await ig(['create', spec, '--no-push'])).stdout)
+
+    const id = sourceRef.split('.').slice(1).join('.')
+    const linked = {
+      id,
+      type: 'NOTE',
+      name: 'e2e source',
+      instruction: 'source',
+      relations: { root: [{ ref: targetRef }], mentions: [{ ref: targetRef }], drops: [{ ref: dropRef }] },
+    }
+    writeFileSync(spec, JSON.stringify(linked))
+    assert.equal((await ig(['create', spec, '--update', '--no-push'])).code, 0)
+    assert.equal((await fn('publish', sourceRef)).code, 0)
+
+    const before = JSON.parse((await fn('inbound', dropRef)).stdout)
+    assert.deepEqual(before[sourceRef].relations, ['drops'])
+
+    // Next revision drops it. The index only learns that if we poke it too.
+    delete linked.relations.drops
+    writeFileSync(spec, JSON.stringify(linked))
+    assert.equal((await ig(['create', spec, '--update', '--no-push'])).code, 0)
+
+    const publish = await fn('publish', sourceRef)
+    assert.equal(publish.code, 0, publish.stderr)
+    assert.match(publish.stderr, /tombstoning/)
+
+    const after = JSON.parse((await fn('inbound', dropRef)).stdout)
+    assert.deepEqual(after[sourceRef].relations, [], 'observed absence is the tombstone')
+    assert.ok(after[sourceRef].revision > before[sourceRef].revision)
+  })
+
   it('an object nothing has pointed at has no index yet', async () => {
     // targetRef itself points at nobody but its author, and nothing points at
     // that author here, so the author's index exists while a fresh object's

--- a/test/freenet-e2e.test.js
+++ b/test/freenet-e2e.test.js
@@ -1,0 +1,196 @@
+/**
+ * End-to-end against a REAL Freenet node and the REAL pinned contracts.
+ *
+ * Skipped unless explicitly enabled, because it needs artifacts and a node
+ * that a plain `npm test` has no business assuming.
+ *
+ *   # 1. the pinned contract WASMs (dataverse_object.wasm,
+ *   #    dataverse_object_rev.wasm, dataverse_inbound_index.wasm)
+ *   export IG_FREENET_E2E_CONTRACTS=/path/to/contracts
+ *
+ *   # 2. a LOCAL-MODE node of your own — never a shared/network node
+ *   freenet local --ws-api-address 127.0.0.1 --ws-api-port 7511 \
+ *     --config-dir ~/.cache/ig-freenet-e2e/config \
+ *     --data-dir   ~/.cache/ig-freenet-e2e/data
+ *   export IG_FREENET_E2E_PORT=7511
+ *
+ *   node --test test/freenet-e2e.test.js
+ *
+ * With only IG_FREENET_E2E_CONTRACTS set, the golden-id assertions still run
+ * offline — those alone catch a WASM swap, which silently relocates the entire
+ * keyspace. The live half additionally signs its OWN throwaway objects and
+ * publishes them for real, so it needs no private envelopes from anyone's store.
+ */
+
+import { describe, it, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { execFile as execFileCb } from 'node:child_process'
+import { promisify } from 'node:util'
+import { rm } from 'node:fs/promises'
+import { writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { setupIgStore } from '../test-support/ig-store.js'
+import { loadContracts } from '../src/freenet/contracts.js'
+import { createAddressing } from '../src/freenet/addressing.js'
+
+const execFile = promisify(execFileCb)
+const CLI = join(import.meta.dirname, '..', 'cli', 'ig.js')
+
+const CONTRACTS = process.env.IG_FREENET_E2E_CONTRACTS
+const PORT = process.env.IG_FREENET_E2E_PORT
+
+const noContracts = !CONTRACTS && 'set IG_FREENET_E2E_CONTRACTS to the pinned contracts dir'
+const noNode = (!CONTRACTS || !PORT) && 'set IG_FREENET_E2E_CONTRACTS and IG_FREENET_E2E_PORT (local-mode node)'
+
+/**
+ * Live-verified golden ids from the inbound-index spike (2026-06-11). These
+ * are what `fdev execute get-contract-id` derives and what was actually
+ * published to a node — so they pin our derivation to the real keyspace.
+ */
+const GOLDEN = {
+  identity: {
+    ref: 'ApWJVWXvVKIIMnH6CP6u8HUyU2gLvyYGnwRlgrWAUwcP.00000000-0000-0000-0000-000000000001',
+    revision: 3,
+    head: 'DWzw99Gtxyhu1gDjNKJcVfSsfw9HmEjNLwUrHmxY4VWB',
+    index: 'FQ6Qbh6Y9N2syWVciUNtJoeEL28wCq1UNzRDfUJGNKTp',
+    snapshot: '7GHNZLEQToEYz7Z6Jy6e7JqsSKNB4jgxUru1CwjnucbY',
+  },
+  root: {
+    ref: 'AxyU5_5vWmP2tO_klN4UpbZzRsuJEvJTrdwdg_gODxZJ.00000000-0000-0000-0000-000000000000',
+    revision: 41,
+    snapshot: 'ExUAkBcvqWMicnkDwPCn6zf6wxAXU2Nc6Ee6Lbpyzpc8',
+  },
+}
+
+/** BLAKE3 of the pinned WASMs, as recorded when they were frozen. */
+const PINNED_CODE_HASHES = {
+  object: '6631a15614c55e96d5297c459461bbb63ec47fd7a4fa6050e2cf104815ed3ff0',
+  snapshot: 'f2e5cf0d8f7ddd588fd2edd782e224bb146593ec0910b8d1dd0635e161c92c44',
+  index: '27d3ea150dd78b093b0afcc2b62b43147690a2da1b0e9f5e3ea71c8b4a6c6568',
+}
+
+const toHex = (bytes) => [...bytes].map(b => b.toString(16).padStart(2, '0')).join('')
+
+describe('freenet e2e — pinned contracts', { skip: noContracts }, () => {
+  it('the contracts directory holds the exact pinned WASMs', () => {
+    const { codeHashes } = loadContracts(CONTRACTS)
+    for (const [role, expected] of Object.entries(PINNED_CODE_HASHES)) {
+      assert.equal(toHex(codeHashes[role]), expected, `${role} WASM is not the pinned build`)
+    }
+  })
+
+  it('derives the live-verified golden contract ids', () => {
+    const addressing = createAddressing(loadContracts(CONTRACTS).codeHashes)
+    const { identity, root } = GOLDEN
+    assert.equal(addressing.headId(identity.ref), identity.head)
+    assert.equal(addressing.indexId(identity.ref), identity.index)
+    assert.equal(addressing.snapshotId(identity.ref, identity.revision), identity.snapshot)
+    assert.equal(addressing.snapshotId(root.ref, root.revision), root.snapshot)
+  })
+})
+
+describe('freenet e2e — live node', { skip: noNode }, () => {
+  let store, sourceRef, targetRef, sourceEnv
+
+  /** Run the CLI against the live node; never throws. */
+  async function ig(args) {
+    try {
+      const r = await execFile(process.execPath, [CLI, ...args], {
+        env: { ...process.env, INSTRUCTIONGRAPH_DIR: store.dir },
+      })
+      return { ...r, code: 0 }
+    } catch (err) {
+      return { stdout: err.stdout ?? '', stderr: err.stderr ?? '', code: err.code ?? 1 }
+    }
+  }
+
+  const fn = (...args) => ig(['freenet', ...args, '--contracts-dir', CONTRACTS, '--port', PORT])
+  const lastLine = (s) => s.trim().split('\n').pop().trim()
+
+  before(async () => {
+    // The contracts only accept objects in the dataverse001 realm.
+    store = await setupIgStore({ realm: 'dataverse001' })
+    const spec = join(store.dir, 'spec.json')
+
+    writeFileSync(spec, JSON.stringify({ type: 'NOTE', name: 'e2e target', instruction: 'target' }))
+    targetRef = lastLine((await ig(['create', spec, '--no-push'])).stdout)
+
+    writeFileSync(spec, JSON.stringify({
+      type: 'NOTE',
+      name: 'e2e source',
+      instruction: 'source',
+      relations: { root: [{ ref: targetRef }], mentions: [{ ref: targetRef }] },
+    }))
+    sourceRef = lastLine((await ig(['create', spec, '--no-push'])).stdout)
+    sourceEnv = JSON.parse((await ig(['get', sourceRef])).stdout)
+  })
+
+  after(async () => {
+    if (store?.dir) await rm(store.dir, { recursive: true, force: true })
+  })
+
+  it('publishes, pokes every target, and reports them all ok', async () => {
+    const { code, stderr } = await fn('publish', sourceRef)
+    assert.equal(code, 0, stderr)
+    assert.match(stderr, /confirmed: the node holds our signature/)
+    assert.doesNotMatch(stderr, /✗/)
+  })
+
+  it('the target index lists the source with only the relations that point at it', async () => {
+    const { stdout, code } = await fn('inbound', targetRef)
+    assert.equal(code, 0)
+    const slots = JSON.parse(stdout)
+    // The contract wrote this slot from the snapshot it fetched and re-invoked
+    // with — we cannot author slot content, only point at a source.
+    assert.deepEqual(slots[sourceRef], {
+      revision: sourceEnv.item.revision ?? 0,
+      relations: ['mentions', 'root'],
+    })
+    // `author` points at the identity object, not at us, so it must not leak in.
+    assert.equal(Object.keys(slots).length, 1)
+  })
+
+  it('verifies every slot as current against its snapshot', async () => {
+    const { stdout, code } = await fn('verify', targetRef)
+    assert.equal(code, 0)
+    assert.match(stdout, /verified-current/)
+    assert.doesNotMatch(stdout, /unverified/)
+  })
+
+  it('re-publishing is an idempotent no-op — the index does not change', async () => {
+    const before = (await fn('inbound', targetRef)).stdout
+    const republish = await fn('publish', sourceRef)
+    assert.equal(republish.code, 0)
+    // DEV-2: every index is local now, so none is re-published.
+    assert.doesNotMatch(republish.stderr, /index not on node/)
+    assert.equal((await fn('inbound', targetRef)).stdout, before)
+  })
+
+  it('reads the head, and the same envelope at its explicit revision', async () => {
+    const head = await fn('get', sourceRef)
+    assert.equal(head.code, 0)
+    assert.deepEqual(JSON.parse(head.stdout), sourceEnv)
+
+    const snap = await fn('get', sourceRef, '--rev', String(sourceEnv.item.revision ?? 0))
+    assert.equal(snap.code, 0)
+    assert.deepEqual(JSON.parse(snap.stdout), sourceEnv)
+  })
+
+  it('a never-published revision is a clean not-found, never a head fallback', async () => {
+    const { code, stdout, stderr } = await fn('get', sourceRef, '--rev', '9999', '--timeout', '15')
+    assert.equal(code, 1)
+    assert.equal(stdout.trim(), '', 'nothing on stdout — silence is the honest answer')
+    assert.match(stderr, /not found|revision 9999/i)
+  })
+
+  it('an object nothing has pointed at has no index yet', async () => {
+    // targetRef itself points at nobody but its author, and nothing points at
+    // that author here, so the author's index exists while a fresh object's
+    // does not. Use a ref that is definitely untouched.
+    const untouched = `${store.pubkey}.99999999-9999-4999-8999-999999999999`
+    const { code, stderr } = await fn('inbound', untouched, '--timeout', '15')
+    assert.equal(code, 1)
+    assert.match(stderr, /poked|not exist/i)
+  })
+})

--- a/test/freenet-hash.test.js
+++ b/test/freenet-hash.test.js
@@ -1,0 +1,108 @@
+/**
+ * BLAKE3 + base58 — the two primitives Freenet contract addressing needs and
+ * Node's stdlib doesn't provide.
+ *
+ * BLAKE3 is checked against the OFFICIAL test vectors from the BLAKE3
+ * reference repository (test_vectors/test_vectors.json, retrieved 2026-07-28
+ * from https://raw.githubusercontent.com/BLAKE3-team/BLAKE3/master/test_vectors/test_vectors.json).
+ * The subset kept below spans every structural boundary of the algorithm:
+ * empty, sub-block, exact block (64), chunk boundaries (1023/1024/1025), and
+ * multi-level merkle trees up to 102400 bytes.
+ *
+ * Per those vectors, input of length N is the repeating 251-byte pattern
+ * 0, 1, 2, ..., 250, 0, 1, ...
+ */
+
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { blake3 } from '../src/freenet/blake3.js'
+import { base58Encode, base58Decode } from '../src/freenet/base58.js'
+
+/** The official vectors' input generator: repeating 0..250. */
+function patternInput(len) {
+  const out = new Uint8Array(len)
+  for (let i = 0; i < len; i++) out[i] = i % 251
+  return out
+}
+
+const toHex = (bytes) => [...bytes].map(b => b.toString(16).padStart(2, '0')).join('')
+
+// [input_len, expected 256-bit hash]
+const VECTORS = [
+  [0, 'af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262'],
+  [1, '2d3adedff11b61f14c886e35afa036736dcd87a74d27b5c1510225d0f592e213'],
+  [2, '7b7015bb92cf0b318037702a6cdd81dee41224f734684c2c122cd6359cb1ee63'],
+  [3, 'e1be4d7a8ab5560aa4199eea339849ba8e293d55ca0a81006726d184519e647f'],
+  [63, 'e9bc37a594daad83be9470df7f7b3798297c3d834ce80ba85d6e207627b7db7b'],
+  [64, '4eed7141ea4a5cd4b788606bd23f46e212af9cacebacdc7d1f4c6dc7f2511b98'],
+  [65, 'de1e5fa0be70df6d2be8fffd0e99ceaa8eb6e8c93a63f2d8d1c30ecb6b263dee'],
+  [127, 'd81293fda863f008c09e92fc382a81f5a0b4a1251cba1634016a0f86a6bd640d'],
+  [128, 'f17e570564b26578c33bb7f44643f539624b05df1a76c81f30acd548c44b45ef'],
+  [129, '683aaae9f3c5ba37eaaf072aed0f9e30bac0865137bae68b1fde4ca2aebdcb12'],
+  [1023, '10108970eeda3eb932baac1428c7a2163b0e924c9a9e25b35bba72b28f70bd11'],
+  [1024, '42214739f095a406f3fc83deb889744ac00df831c10daa55189b5d121c855af7'],
+  [1025, 'd00278ae47eb27b34faecf67b4fe263f82d5412916c1ffd97c8cb7fb814b8444'],
+  [2048, 'e776b6028c7cd22a4d0ba182a8bf62205d2ef576467e838ed6f2529b85fba24a'],
+  [2049, '5f4d72f40d7a5f82b15ca2b2e44b1de3c2ef86c426c95c1af0b6879522563030'],
+  [3072, 'b98cb0ff3623be03326b373de6b9095218513e64f1ee2edd2525c7ad1e5cffd2'],
+  [4096, '015094013f57a5277b59d8475c0501042c0b642e531b0a1c8f58d2163229e969'],
+  [4097, '9b4052b38f1c5fc8b1f9ff7ac7b27cd242487b3d890d15c96a1c25b8aa0fb995'],
+  [8192, 'aae792484c8efe4f19e2ca7d371d8c467ffb10748d8a5a1ae579948f718a2a63'],
+  [8193, 'bab6c09cb8ce8cf459261398d2e7aef35700bf488116ceb94a36d0f5f1b7bc3b'],
+  [16384, 'f875d6646de28985646f34ee13be9a576fd515f76b5b0a26bb324735041ddde4'],
+  [31744, '62b6960e1a44bcc1eb1a611a8d6235b6b4b78f32e7abc4fb4c6cdcce94895c47'],
+  [102400, 'bc3e3d41a1146b069abffad3c0d44860cf664390afce4d9661f7902e7943e085'],
+]
+
+test('blake3 matches the official BLAKE3 test vectors', () => {
+  for (const [len, expected] of VECTORS) {
+    assert.equal(toHex(blake3(patternInput(len))), expected, `input_len ${len}`)
+  }
+})
+
+test('blake3 returns 32 bytes as a Uint8Array', () => {
+  const h = blake3(new Uint8Array(0))
+  assert.ok(h instanceof Uint8Array)
+  assert.equal(h.length, 32)
+})
+
+test('blake3 accepts concatenated input the same as a single buffer', () => {
+  // Address derivation always hashes code_hash ‖ params; guard the join.
+  const a = patternInput(32)
+  const b = patternInput(40)
+  const joined = new Uint8Array(a.length + b.length)
+  joined.set(a, 0)
+  joined.set(b, a.length)
+  assert.equal(toHex(blake3(joined)).length, 64)
+  assert.notEqual(toHex(blake3(joined)), toHex(blake3(a)))
+})
+
+test('base58 encodes the Bitcoin alphabet without 0OIl', () => {
+  // Vectors from the Bitcoin base58 spec (no checksum, raw payload).
+  assert.equal(base58Encode(new Uint8Array([])), '')
+  assert.equal(base58Encode(new Uint8Array([0])), '1')
+  assert.equal(base58Encode(new Uint8Array([0, 0, 1])), '112')
+  assert.equal(base58Encode(new TextEncoder().encode('Hello World!')), '2NEpo7TZRRrLZSi2U')
+  assert.equal(
+    base58Encode(new TextEncoder().encode('The quick brown fox jumps over the lazy dog.')),
+    'USm3fpXnKG5EUBx2ndxBDMPVciP5hGey2Jh4NDv6gmeo1LkMeiKrLJUUBk6Z',
+  )
+})
+
+test('base58 round-trips arbitrary bytes, leading zeros included', () => {
+  const cases = [
+    new Uint8Array([]),
+    new Uint8Array([0, 0, 0, 5, 200, 255]),
+    patternInput(32),
+    new Uint8Array(32), // all zeros
+  ]
+  for (const bytes of cases) {
+    assert.deepEqual(base58Decode(base58Encode(bytes)), bytes)
+  }
+})
+
+test('base58Decode rejects characters outside the alphabet', () => {
+  assert.throws(() => base58Decode('abc0def'), /base58/i)
+  assert.throws(() => base58Decode('OIl'), /base58/i)
+})

--- a/test/freenet-node.test.js
+++ b/test/freenet-node.test.js
@@ -119,7 +119,7 @@ test('loadContracts reports a missing contracts directory distinctly', () => {
 // ─── fdev argv ───────────────────────────────────────────────────
 
 test('get issues `fdev -p PORT execute get <id> --output <file> --timeout <s>`', async () => {
-  const { exec, calls } = fakeExec([{ code: 1 }])
+  const { exec, calls } = fakeExec([{ code: 1, stderr: 'client error: missing contract: ID' }])
   const n = createFdevNode({ fdevPath: '/opt/fdev', port: 7511, exec, timeoutMs: 30_000 })
   await n.get('SOMECONTRACTID')
   assert.equal(calls[0].file, '/opt/fdev')
@@ -131,7 +131,7 @@ test('get issues `fdev -p PORT execute get <id> --output <file> --timeout <s>`',
 test('fdev gets its own --timeout, and the process bound sits above it', async () => {
   // fdev can give up cleanly and explain itself; SIGKILL cannot. So fdev's
   // deadline must fire FIRST, with the process kill only as a hard backstop.
-  const { exec, calls } = fakeExec([{ code: 1 }])
+  const { exec, calls } = fakeExec([{ code: 1, stderr: 'client error: missing contract: ID' }])
   const n = createFdevNode({ fdevPath: 'fdev', port: 7509, exec, timeoutMs: 20_000 })
   await n.get('ID')
   const fdevTimeoutS = Number(calls[0].args[calls[0].args.indexOf('--timeout') + 1])
@@ -263,9 +263,57 @@ test('the DEV-2 probe uses its own short timeout, not the read timeout', async (
   // DEV-2: a locally hosted contract answers in well under a second, so 5 s
   // separates "already here" from "would go to the network" without ever
   // waiting out the node's fetch budget. It must not inherit --timeout.
-  const { exec, calls } = fakeExec([{ code: 1 }])
+  const { exec, calls } = fakeExec([{ code: 1, stderr: 'client error: missing contract: ID' }])
   const n = createFdevNode({ fdevPath: 'fdev', port: 7509, exec, timeoutMs: 60_000, probeTimeoutMs: 5_000 })
   await n.probe('ID')
   assert.equal(calls[0].args[calls[0].args.indexOf('--timeout') + 1], '5')
   assert.ok(calls[0].opts.timeoutMs < 60_000, 'process bound stays near the probe bound')
+})
+
+// ─── operational failure vs genuine absence ──────────────────────
+
+test('a non-ENOENT spawn failure (e.g. EACCES) is still a spawn failure', async () => {
+  // execFile reports spawn problems with a STRING code and exit failures with
+  // a number; anything non-numeric must not fall through as a contract miss.
+  const { exec } = fakeExec([{ spawnError: Object.assign(new Error('permission denied'), { code: 'EACCES' }) }])
+  const n = createFdevNode({ fdevPath: '/root/fdev', port: 7509, exec })
+  await assert.rejects(() => n.get('ID'), (err) => {
+    assert.match(err.message, /\/root\/fdev/)
+    assert.doesNotMatch(err.message, /not found on the node/i)
+    return true
+  })
+})
+
+test('an unreachable node is an error, not "contract not found"', async () => {
+  // fdev's real wording, captured from the binary on 2026-07-28.
+  const { exec } = fakeExec([{
+    code: 1,
+    stderr: 'Error: failed to connect to the host(ws://127.0.0.1:7599/v1/contract/command): IO error: Connection refused (os error 111)',
+  }])
+  const n = createFdevNode({ fdevPath: 'fdev', port: 7599, exec })
+  await assert.rejects(() => n.get('ID'), (err) => {
+    assert.match(err.message, /could not reach|connect/i)
+    assert.match(err.message, /7599/, 'names the port, the usual cause')
+    return true
+  })
+})
+
+test('a genuine miss is reported as a miss, not an error', async () => {
+  const { exec } = fakeExec([{ code: 1, stderr: 'Error: Failed to receive response: client error: missing contract: ABC' }])
+  const res = await createFdevNode({ fdevPath: 'fdev', port: 7509, exec }).get('ABC')
+  assert.equal(res.found, false)
+  assert.equal(res.operational, false)
+  assert.match(res.detail, /not found/i)
+})
+
+test('an unrecognised failure is surfaced, never silently treated as absence', async () => {
+  const { exec } = fakeExec([{ code: 3, stderr: 'Error: something nobody predicted' }])
+  const n = createFdevNode({ fdevPath: 'fdev', port: 7509, exec })
+  await assert.rejects(() => n.get('ID'), /something nobody predicted/)
+})
+
+test('a probe treats an unreachable node as an error, so DEV-2 cannot mass-create indexes', async () => {
+  const { exec } = fakeExec([{ code: 1, stderr: 'Error: failed to connect to the host(ws://x): Connection refused' }])
+  const n = createFdevNode({ fdevPath: 'fdev', port: 7509, exec })
+  await assert.rejects(() => n.probe('ID'), /could not reach|connect/i)
 })

--- a/test/freenet-node.test.js
+++ b/test/freenet-node.test.js
@@ -1,0 +1,271 @@
+/**
+ * Freenet config resolution and the fdev node client.
+ *
+ * The node client is exercised against an INJECTED exec, so these tests never
+ * spawn fdev and never touch a node. What they pin down is the part that is
+ * easy to get quietly wrong: the exact argv we hand fdev (a drifted flag
+ * publishes into the wrong keyspace), and the error classification — a user
+ * staring at "command failed" learns nothing, so every failure mode has to
+ * come back as its own diagnosable message.
+ */
+
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtemp, writeFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { resolveFreenetConfig, FREENET_CONFIG_KEYS } from '../src/freenet/config.js'
+import { createFdevNode } from '../src/freenet/fdev.js'
+import { loadContracts } from '../src/freenet/contracts.js'
+
+/** A fake exec that records calls and replays scripted results. */
+function fakeExec(results = []) {
+  const calls = []
+  const queue = [...results]
+  const exec = async (file, args, opts) => {
+    calls.push({ file, args, opts })
+    const next = queue.shift() ?? { code: 0, stdout: '', stderr: '' }
+    if (typeof next === 'function') return next({ file, args, opts })
+    return { code: 0, stdout: '', stderr: '', timedOut: false, spawnError: null, ...next }
+  }
+  return { exec, calls }
+}
+
+const node = (opts = {}) => createFdevNode({
+  fdevPath: 'fdev', port: 7509, exec: fakeExec().exec, ...opts,
+})
+
+// ─── config ──────────────────────────────────────────────────────
+
+test('config falls back to documented defaults', () => {
+  const cfg = resolveFreenetConfig(() => null, { contractsDir: '/pinned' })
+  assert.equal(cfg.port, 7509)
+  assert.equal(cfg.fdevPath, 'fdev')
+  assert.equal(cfg.contractsDir, '/pinned')
+})
+
+test('config reads stored keys and lets flags win', () => {
+  const stored = {
+    [FREENET_CONFIG_KEYS.port]: '7511',
+    [FREENET_CONFIG_KEYS.fdev]: '/opt/fdev',
+    [FREENET_CONFIG_KEYS.contractsDir]: '/stored/contracts',
+  }
+  const read = (k) => stored[k] ?? null
+  assert.equal(resolveFreenetConfig(read, {}).port, 7511)
+  assert.equal(resolveFreenetConfig(read, {}).fdevPath, '/opt/fdev')
+  assert.equal(resolveFreenetConfig(read, {}).contractsDir, '/stored/contracts')
+  assert.equal(resolveFreenetConfig(read, { port: 7599 }).port, 7599)
+  assert.equal(resolveFreenetConfig(read, { contractsDir: '/flag' }).contractsDir, '/flag')
+})
+
+test('config explains how to fix an unset contracts dir', () => {
+  assert.throws(() => resolveFreenetConfig(() => null, {}), (err) => {
+    assert.match(err.message, /contracts/i)
+    assert.match(err.message, new RegExp(FREENET_CONFIG_KEYS.contractsDir), 'names the config key')
+    assert.match(err.message, /--contracts-dir/, 'names the flag')
+    return true
+  })
+})
+
+test('config rejects a nonsense port instead of passing it to fdev', () => {
+  assert.throws(
+    () => resolveFreenetConfig(() => null, { contractsDir: '/c', port: 'seven' }),
+    /port/i,
+  )
+  assert.throws(
+    () => resolveFreenetConfig((k) => (k === FREENET_CONFIG_KEYS.port ? '0' : null), { contractsDir: '/c' }),
+    /port/i,
+  )
+})
+
+// ─── contracts dir ───────────────────────────────────────────────
+
+test('loadContracts hashes the three pinned WASMs', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'ig-fn-contracts-'))
+  try {
+    await writeFile(join(dir, 'dataverse_object.wasm'), 'a')
+    await writeFile(join(dir, 'dataverse_object_rev.wasm'), 'b')
+    await writeFile(join(dir, 'dataverse_inbound_index.wasm'), 'c')
+    const c = loadContracts(dir)
+    assert.equal(c.codeHashes.object.length, 32)
+    assert.equal(c.codeHashes.snapshot.length, 32)
+    assert.equal(c.codeHashes.index.length, 32)
+    assert.equal(c.paths.object, join(dir, 'dataverse_object.wasm'))
+    assert.notDeepEqual(c.codeHashes.object, c.codeHashes.snapshot)
+  } finally {
+    await rm(dir, { recursive: true, force: true })
+  }
+})
+
+test('loadContracts names the missing file and the directory it looked in', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'ig-fn-contracts-'))
+  try {
+    await writeFile(join(dir, 'dataverse_object.wasm'), 'a')
+    assert.throws(() => loadContracts(dir), (err) => {
+      assert.match(err.message, /dataverse_object_rev\.wasm/)
+      assert.match(err.message, new RegExp(dir.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')))
+      return true
+    })
+  } finally {
+    await rm(dir, { recursive: true, force: true })
+  }
+})
+
+test('loadContracts reports a missing contracts directory distinctly', () => {
+  assert.throws(() => loadContracts('/definitely/not/here'), /not a directory|does not exist/i)
+})
+
+// ─── fdev argv ───────────────────────────────────────────────────
+
+test('get issues `fdev -p PORT execute get <id> --output <file> --timeout <s>`', async () => {
+  const { exec, calls } = fakeExec([{ code: 1 }])
+  const n = createFdevNode({ fdevPath: '/opt/fdev', port: 7511, exec, timeoutMs: 30_000 })
+  await n.get('SOMECONTRACTID')
+  assert.equal(calls[0].file, '/opt/fdev')
+  assert.deepEqual(calls[0].args.slice(0, 5), ['-p', '7511', 'execute', 'get', 'SOMECONTRACTID'])
+  assert.ok(calls[0].args.includes('--output'))
+  assert.equal(calls[0].args[calls[0].args.indexOf('--timeout') + 1], '30', 'fdev timeout in seconds')
+})
+
+test('fdev gets its own --timeout, and the process bound sits above it', async () => {
+  // fdev can give up cleanly and explain itself; SIGKILL cannot. So fdev's
+  // deadline must fire FIRST, with the process kill only as a hard backstop.
+  const { exec, calls } = fakeExec([{ code: 1 }])
+  const n = createFdevNode({ fdevPath: 'fdev', port: 7509, exec, timeoutMs: 20_000 })
+  await n.get('ID')
+  const fdevTimeoutS = Number(calls[0].args[calls[0].args.indexOf('--timeout') + 1])
+  assert.equal(fdevTimeoutS, 20)
+  assert.ok(
+    calls[0].opts.timeoutMs > fdevTimeoutS * 1000,
+    `process bound ${calls[0].opts.timeoutMs}ms must exceed fdev's ${fdevTimeoutS}s`,
+  )
+})
+
+test('get returns the parsed state and found=true', async () => {
+  const { exec } = fakeExec([
+    async ({ args }) => {
+      const out = args[args.indexOf('--output') + 1]
+      await writeFile(out, JSON.stringify({ v: 1, slots: {} }))
+      return { code: 0 }
+    },
+  ])
+  const res = await createFdevNode({ fdevPath: 'fdev', port: 7509, exec }).get('ID')
+  assert.equal(res.found, true)
+  assert.deepEqual(res.state, { v: 1, slots: {} })
+})
+
+test('get reports not-found rather than throwing, and says so plainly', async () => {
+  const { exec } = fakeExec([{ code: 1, stderr: 'contract not found' }])
+  const res = await createFdevNode({ fdevPath: 'fdev', port: 7509, exec }).get('ID')
+  assert.equal(res.found, false)
+  assert.equal(res.state, null)
+  assert.match(res.detail, /not found|no state/i)
+})
+
+test('an empty output file is a miss, not an empty state', async () => {
+  const { exec } = fakeExec([
+    async ({ args }) => {
+      await writeFile(args[args.indexOf('--output') + 1], '')
+      return { code: 0 }
+    },
+  ])
+  const res = await createFdevNode({ fdevPath: 'fdev', port: 7509, exec }).get('ID')
+  assert.equal(res.found, false)
+})
+
+test('a timed-out GET is distinguished from a miss and explains why it is slow', async () => {
+  const { exec } = fakeExec([{ code: null, timedOut: true }])
+  const res = await createFdevNode({ fdevPath: 'fdev', port: 7509, exec, timeoutMs: 4000 }).get('ID')
+  assert.equal(res.found, false)
+  assert.equal(res.timedOut, true)
+  assert.match(res.detail, /timed out/i)
+  assert.match(res.detail, /4/, 'names the timeout that elapsed')
+})
+
+test('a missing fdev binary is reported as such, with the path tried', async () => {
+  const { exec } = fakeExec([{ spawnError: Object.assign(new Error('spawn'), { code: 'ENOENT' }) }])
+  const n = createFdevNode({ fdevPath: '/no/such/fdev', port: 7509, exec })
+  await assert.rejects(() => n.get('ID'), (err) => {
+    assert.match(err.message, /fdev/)
+    assert.match(err.message, /\/no\/such\/fdev/)
+    assert.match(err.message, /freenet-fdev|PATH/i, 'tells the user how to fix it')
+    return true
+  })
+})
+
+test('publish issues `fdev -p PORT publish --code W --parameters P contract --state S`', async () => {
+  const { exec, calls } = fakeExec([{ code: 0 }])
+  const n = createFdevNode({ fdevPath: 'fdev', port: 7509, exec, putTimeoutMs: 330_000 })
+  await n.publish({ wasmPath: '/w.wasm', params: new Uint8Array([1, 2]), state: { hello: 1 } })
+  const a = calls[0].args
+  assert.deepEqual(a.slice(0, 4), ['-p', '7509', 'publish', '--code'])
+  assert.equal(a[4], '/w.wasm')
+  assert.equal(a[5], '--parameters')
+  // --timeout belongs to `publish`, so it must precede the `contract` subcommand.
+  assert.ok(a.indexOf('--timeout') > 0 && a.indexOf('--timeout') < a.indexOf('contract'))
+  assert.equal(a[a.indexOf('--timeout') + 1], '330')
+  assert.equal(a[a.indexOf('contract') + 1], '--state')
+})
+
+test('update issues `fdev -p PORT execute update <id> <payload-file>`', async () => {
+  const { exec, calls } = fakeExec([{ code: 0 }])
+  const n = createFdevNode({ fdevPath: 'fdev', port: 7509, exec })
+  await n.update('THEID', { v: 1, poke: { source_ref: 'x.y', revision: 1 } })
+  const a = calls[0].args
+  assert.deepEqual(a.slice(0, 4), ['-p', '7509', 'execute', 'update'])
+  assert.equal(a[4], 'THEID')
+  assert.equal(a[5].endsWith('payload.json'), true, 'delta file is the second positional')
+})
+
+test('a failed publish surfaces fdev stderr, ANSI stripped', async () => {
+  const { exec } = fakeExec([{ code: 1, stderr: '[31mError: put timed out after 1 peer attempt(s)[0m' }])
+  const n = createFdevNode({ fdevPath: 'fdev', port: 7509, exec })
+  await assert.rejects(
+    () => n.publish({ wasmPath: '/w.wasm', params: new Uint8Array([1]), state: {} }),
+    (err) => {
+      assert.match(err.message, /put timed out after 1 peer attempt/)
+      assert.doesNotMatch(err.message, /\[/, 'ANSI escapes stripped')
+      return true
+    },
+  )
+})
+
+test('a timed-out write says how long it waited and that the node may be unreachable', async () => {
+  const { exec } = fakeExec([{ timedOut: true }])
+  const n = createFdevNode({ fdevPath: 'fdev', port: 7509, exec, putTimeoutMs: 12000 })
+  await assert.rejects(
+    () => n.publish({ wasmPath: '/w.wasm', params: new Uint8Array([1]), state: {} }),
+    (err) => {
+      assert.match(err.message, /timed out/i)
+      assert.match(err.message, /12/)
+      assert.match(err.message, /7509/, 'names the port, so a wrong-port config is obvious')
+      return true
+    },
+  )
+})
+
+test('node operations clean up their temp files', async () => {
+  const seen = []
+  const { exec } = fakeExec([
+    async ({ args }) => {
+      seen.push(args[args.indexOf('--parameters') + 1], args[args.indexOf('--state') + 1])
+      return { code: 0 }
+    },
+  ])
+  const n = createFdevNode({ fdevPath: 'fdev', port: 7509, exec })
+  await n.publish({ wasmPath: '/w.wasm', params: new Uint8Array([1]), state: {} })
+  const { existsSync } = await import('node:fs')
+  for (const p of seen) assert.equal(existsSync(p), false, `temp file left behind: ${p}`)
+})
+
+test('the DEV-2 probe uses its own short timeout, not the read timeout', async () => {
+  // DEV-2: a locally hosted contract answers in well under a second, so 5 s
+  // separates "already here" from "would go to the network" without ever
+  // waiting out the node's fetch budget. It must not inherit --timeout.
+  const { exec, calls } = fakeExec([{ code: 1 }])
+  const n = createFdevNode({ fdevPath: 'fdev', port: 7509, exec, timeoutMs: 60_000, probeTimeoutMs: 5_000 })
+  await n.probe('ID')
+  assert.equal(calls[0].args[calls[0].args.indexOf('--timeout') + 1], '5')
+  assert.ok(calls[0].opts.timeoutMs < 60_000, 'process bound stays near the probe bound')
+})

--- a/test/freenet-node.test.js
+++ b/test/freenet-node.test.js
@@ -156,22 +156,26 @@ test('get returns the parsed state and found=true', async () => {
 })
 
 test('get reports not-found rather than throwing, and says so plainly', async () => {
-  const { exec } = fakeExec([{ code: 1, stderr: 'contract not found' }])
+  // fdev's real wording for a genuine miss (0.3.274): exit 1, no output file.
+  const { exec } = fakeExec([{ code: 1, stderr: 'client error: missing contract: ID' }])
   const res = await createFdevNode({ fdevPath: 'fdev', port: 7509, exec }).get('ID')
   assert.equal(res.found, false)
   assert.equal(res.state, null)
   assert.match(res.detail, /not found|no state/i)
 })
 
-test('an empty output file is a miss, not an empty state', async () => {
+test('exit 0 with no state is anomalous, and is surfaced rather than called absence', async () => {
+  // fdev signals a genuine miss with exit 1 and no output file. Exit 0 with
+  // nothing written is a case we do not understand — and guessing "absent"
+  // is the dangerous guess, because it licenses the flow to create indexes.
   const { exec } = fakeExec([
     async ({ args }) => {
       await writeFile(args[args.indexOf('--output') + 1], '')
       return { code: 0 }
     },
   ])
-  const res = await createFdevNode({ fdevPath: 'fdev', port: 7509, exec }).get('ID')
-  assert.equal(res.found, false)
+  const n = createFdevNode({ fdevPath: 'fdev', port: 7509, exec })
+  await assert.rejects(() => n.get('ID'), /no state|unexpected|exit 0/i)
 })
 
 test('a timed-out GET is distinguished from a miss and explains why it is slow', async () => {
@@ -316,4 +320,13 @@ test('a probe treats an unreachable node as an error, so DEV-2 cannot mass-creat
   const { exec } = fakeExec([{ code: 1, stderr: 'Error: failed to connect to the host(ws://x): Connection refused' }])
   const n = createFdevNode({ fdevPath: 'fdev', port: 7509, exec })
   await assert.rejects(() => n.probe('ID'), /could not reach|connect/i)
+})
+
+test('only fdev\'s explicit missing-contract wording counts as absence', async () => {
+  // A vague "not found" from somewhere else in the stack is not proof that a
+  // contract is absent; broad matching here is how an operational failure
+  // becomes a phantom "nothing is published".
+  const { exec } = fakeExec([{ code: 1, stderr: 'Error: config file not found' }])
+  const n = createFdevNode({ fdevPath: 'fdev', port: 7509, exec })
+  await assert.rejects(() => n.get('ID'), /config file not found/)
 })

--- a/test/freenet-publish.test.js
+++ b/test/freenet-publish.test.js
@@ -406,3 +406,20 @@ test('two spellings of one ref are one target, not two pokes at one index', asyn
   assert.equal(node.calls.filter(c => c.op === 'update').length, 1)
   assert.equal(node.calls.find(c => c.op === 'update').id, ADDRESSING.indexId(AUTHOR))
 })
+
+test('a ref respelled between revisions is not mistaken for a dropped target', async () => {
+  // The previous head spelled the ref with an uppercase uuid; this one uses
+  // lowercase. Same index contract — so it is NOT dropped, and must be poked
+  // once, as a normal target rather than a tombstone.
+  const [pk, uuid] = AUTHOR.split('.')
+  const previous = envelope({ revision: 3, relations: { author: [{ ref: `${pk}.${uuid.toUpperCase()}` }] } })
+  const current = envelope({ revision: 4, relations: { author: [{ ref: AUTHOR }] } })
+  const node = nodeWithSnapshot(current)
+  node.present.set(ADDRESSING.headId(SELF), previous)
+
+  const report = await run(current, node)
+
+  assert.equal(report.pokes.length, 1)
+  assert.equal(report.pokes[0].tombstone, false)
+  assert.equal(node.calls.filter(c => c.op === 'update').length, 1)
+})

--- a/test/freenet-publish.test.js
+++ b/test/freenet-publish.test.js
@@ -110,11 +110,16 @@ test('runs snapshot PUT → GET-back → head PUT → pokes, in that order', asy
   assert.equal(node.calls[0].paramsLen, 40)
   assert.equal(ops[1], 'get', 'GET-back gate second')
   assert.equal(node.calls[1].id, ADDRESSING.snapshotId(SELF, 3))
-  assert.equal(ops[2], 'publish', 'head PUT third')
-  assert.equal(node.calls[2].wasmPath, CONTRACTS.paths.object)
-  assert.equal(node.calls[2].paramsLen, 32)
-  // Everything after the head belongs to the poke phase.
-  assert.ok(node.calls.slice(3).some(c => c.op === 'update'))
+  // 2b: read the previous head before our PUT replaces it (US-2.4).
+  assert.equal(ops[2], 'probe')
+  assert.equal(node.calls[2].id, ADDRESSING.headId(SELF))
+
+  const headPut = node.calls.findIndex(c => c.op === 'publish' && c.wasmPath === CONTRACTS.paths.object)
+  assert.equal(headPut, 3, 'head PUT follows')
+  assert.equal(node.calls[headPut].paramsLen, 32)
+  // Every poke comes after the head.
+  const firstPoke = node.calls.findIndex(c => c.op === 'update')
+  assert.ok(firstPoke > headPut)
   assert.equal(report.failed, 0)
 })
 
@@ -304,4 +309,84 @@ test('re-running makes the identical set of node calls — the flow is idempoten
     first.calls.filter(c => c.op === 'update').map(c => c.payload),
     'the same poke is re-sent; the contract merges it LWW',
   )
+})
+
+// ─── US-2.4: relation removal propagates ─────────────────────────
+
+test('a target dropped since the previous head is still poked, so it can tombstone', async () => {
+  // rev 3 linked ROOT and AUTHOR; rev 4 drops AUTHOR. Poking AUTHOR with
+  // (source, 4) makes its index fetch our rev-4 snapshot, find no relation to
+  // itself, and write {revision: 4, relations: []} — the tombstone (US-2.4).
+  const previous = envelope({ revision: 3, relations: { root: [{ ref: ROOT }], author: [{ ref: AUTHOR }] } })
+  const current = envelope({ revision: 4, relations: { root: [{ ref: ROOT }] } })
+
+  const node = nodeWithSnapshot(current)
+  node.present.set(ADDRESSING.headId(SELF), previous)
+
+  const report = await run(current, node)
+
+  assert.deepEqual(
+    new Set(report.pokes.map(p => p.target)),
+    new Set([ROOT, AUTHOR]),
+    'the dropped target must still be poked',
+  )
+  assert.equal(report.pokes.find(p => p.target === AUTHOR).tombstone, true)
+  assert.equal(report.pokes.find(p => p.target === ROOT).tombstone, false)
+  assert.equal(report.failed, 0)
+})
+
+test('the previous head is read BEFORE it is overwritten', async () => {
+  const previous = envelope({ revision: 3, relations: { author: [{ ref: AUTHOR }] } })
+  const current = envelope({ revision: 4, relations: { root: [{ ref: ROOT }] } })
+  const node = nodeWithSnapshot(current)
+  node.present.set(ADDRESSING.headId(SELF), previous)
+
+  await run(current, node)
+
+  const probeAt = node.calls.findIndex(c => c.op === 'probe' && c.id === ADDRESSING.headId(SELF))
+  const headPut = node.calls.findIndex(c => c.op === 'publish' && c.wasmPath === CONTRACTS.paths.object)
+  assert.ok(probeAt !== -1, 'the previous head is probed')
+  assert.ok(probeAt < headPut, 'and read before our PUT replaces it')
+})
+
+test('a head at or beyond our revision contributes no tombstones', async () => {
+  // Not our predecessor — someone else's newer state, or our own re-publish.
+  const same = envelope({ revision: 3, relations: { author: [{ ref: AUTHOR }] } })
+  const current = envelope({ revision: 3, relations: { root: [{ ref: ROOT }] } })
+  const node = nodeWithSnapshot(current)
+  node.present.set(ADDRESSING.headId(SELF), same)
+
+  const report = await run(current, node)
+  assert.deepEqual(report.pokes.map(p => p.target), [ROOT])
+})
+
+test('no previous head on the node simply means no tombstones', async () => {
+  const env = envelope({ relations: { root: [{ ref: ROOT }] } })
+  const node = fakeNode()
+  node.present.set(ADDRESSING.snapshotId(SELF, 3), env)
+  const report = await run(env, node)
+  assert.deepEqual(report.pokes.map(p => p.target), [ROOT])
+  assert.equal(report.failed, 0)
+})
+
+// ─── head confirmation ───────────────────────────────────────────
+
+test('an unconfirmed head is reported as not confirmed', async () => {
+  const env = envelope({ relations: {} })
+  const node = fakeNode()
+  node.present.set(ADDRESSING.snapshotId(SELF, 3), env)
+  // The head GET-back returns someone else's newer state — LWW kept theirs.
+  node.present.set(ADDRESSING.headId(SELF), { ...env, signature: 'SIG-THEIRS', item: { ...env.item, revision: 9 } })
+
+  const report = await run(env, node)
+  assert.equal(report.headState.confirmed, false)
+  assert.match(report.headState.detail, /9/)
+  assert.equal(report.ok, false, 'the overall result is not a success')
+})
+
+test('a confirmed head with all pokes ok is a success', async () => {
+  const env = envelope({ relations: { root: [{ ref: ROOT }] } })
+  const report = await run(env, nodeWithSnapshot(env))
+  assert.equal(report.headState.confirmed, true)
+  assert.equal(report.ok, true)
 })

--- a/test/freenet-publish.test.js
+++ b/test/freenet-publish.test.js
@@ -390,3 +390,19 @@ test('a confirmed head with all pokes ok is a success', async () => {
   assert.equal(report.headState.confirmed, true)
   assert.equal(report.ok, true)
 })
+
+test('two spellings of one ref are one target, not two pokes at one index', async () => {
+  // Addressing is uuid-case-insensitive, so both spellings resolve to the
+  // same index contract. Poking it twice is wasted work on a flow whose
+  // whole cost is round-trips.
+  const [pk, uuid] = AUTHOR.split('.')
+  const upper = `${pk}.${uuid.toUpperCase()}`
+  assert.notEqual(upper, AUTHOR, 'this uuid must actually contain letters')
+  const env = envelope({ relations: { root: [{ ref: AUTHOR }], alias: [{ ref: upper }] } })
+  const node = nodeWithSnapshot(env)
+  const report = await run(env, node)
+
+  assert.equal(report.pokes.length, 1)
+  assert.equal(node.calls.filter(c => c.op === 'update').length, 1)
+  assert.equal(node.calls.find(c => c.op === 'update').id, ADDRESSING.indexId(AUTHOR))
+})

--- a/test/freenet-publish.test.js
+++ b/test/freenet-publish.test.js
@@ -1,0 +1,307 @@
+/**
+ * The US-3.1 ordered publish flow, against a fake node.
+ *
+ * The ORDER is the point of this flow, not an implementation detail: a poke
+ * makes the target's index fetch the source's snapshot, so poking before the
+ * snapshot is confirmed present stalls every poke for the host's ~240 s fetch
+ * budget and then fails (spike finding). The GET-back gate at step 2 is what
+ * buys that back, and it must abort before ANY poke is sent.
+ */
+
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { publishObject } from '../src/freenet/publish.js'
+import { createAddressing } from '../src/freenet/addressing.js'
+
+const fromHex = (hex) => Uint8Array.from(hex.match(/../g).map(h => parseInt(h, 16)))
+
+const ADDRESSING = createAddressing({
+  object: fromHex('6631a15614c55e96d5297c459461bbb63ec47fd7a4fa6050e2cf104815ed3ff0'),
+  snapshot: fromHex('f2e5cf0d8f7ddd588fd2edd782e224bb146593ec0910b8d1dd0635e161c92c44'),
+  index: fromHex('27d3ea150dd78b093b0afcc2b62b43147690a2da1b0e9f5e3ea71c8b4a6c6568'),
+})
+
+const CONTRACTS = {
+  paths: { object: '/w/object.wasm', snapshot: '/w/rev.wasm', index: '/w/index.wasm' },
+}
+
+const PK = 'ApWJVWXvVKIIMnH6CP6u8HUyU2gLvyYGnwRlgrWAUwcP'
+const OTHER_PK = 'AxyU5_5vWmP2tO_klN4UpbZzRsuJEvJTrdwdg_gODxZJ'
+const SELF = `${PK}.00000000-0000-0000-0000-000000000001`
+const ROOT = `${OTHER_PK}.00000000-0000-0000-0000-000000000000`
+const AUTHOR = `${OTHER_PK}.346bef5e-94ff-4f7a-bcf6-d78ae1e1541c`
+
+function envelope({ revision = 3, relations, signature = 'SIG-A' } = {}) {
+  return {
+    item: {
+      pubkey: PK,
+      id: '00000000-0000-0000-0000-000000000001',
+      revision,
+      in: 'dataverse001',
+      relations: relations ?? {
+        root: [{ ref: ROOT }],
+        author: [{ ref: SELF }],
+      },
+    },
+    signature,
+  }
+}
+
+/**
+ * A fake node recording every call in order.
+ * `present` is the set of contract ids the node already holds.
+ */
+function fakeNode({ present = new Map(), fail = {} } = {}) {
+  const calls = []
+  return {
+    calls,
+    present,
+    async get(id) {
+      calls.push({ op: 'get', id })
+      if (fail.get?.(id)) throw fail.get(id)
+      return present.has(id)
+        ? { found: true, state: present.get(id), timedOut: false, detail: '' }
+        : { found: false, state: null, timedOut: false, detail: 'not found' }
+    },
+    async probe(id) {
+      calls.push({ op: 'probe', id })
+      return present.has(id)
+        ? { found: true, state: present.get(id), timedOut: false, detail: '' }
+        : { found: false, state: null, timedOut: false, detail: 'not found' }
+    },
+    async publish({ wasmPath, params, state }) {
+      calls.push({ op: 'publish', wasmPath, paramsLen: params.length, state })
+      if (fail.publish?.(wasmPath, state)) throw fail.publish(wasmPath, state)
+      return { ok: true, output: '' }
+    },
+    async update(id, payload) {
+      calls.push({ op: 'update', id, payload })
+      if (fail.update?.(id)) throw fail.update(id)
+      return { ok: true, output: '' }
+    },
+  }
+}
+
+/** A node that has already seen this envelope's snapshot and head. */
+function nodeWithSnapshot(env, extra = []) {
+  const present = new Map()
+  const ref = `${env.item.pubkey}.${env.item.id}`
+  present.set(ADDRESSING.snapshotId(ref, env.item.revision ?? 0), env)
+  present.set(ADDRESSING.headId(ref), env)
+  for (const id of extra) present.set(id, { v: 1, slots: {} })
+  return fakeNode({ present })
+}
+
+const run = (env, node) => publishObject({
+  envelope: env, node, addressing: ADDRESSING, contracts: CONTRACTS, log: () => {},
+})
+
+// ─── ordering ────────────────────────────────────────────────────
+
+test('runs snapshot PUT → GET-back → head PUT → pokes, in that order', async () => {
+  const env = envelope()
+  const node = nodeWithSnapshot(env)
+  const report = await run(env, node)
+
+  const ops = node.calls.map(c => c.op)
+  assert.equal(ops[0], 'publish', 'snapshot PUT first')
+  assert.equal(node.calls[0].wasmPath, CONTRACTS.paths.snapshot)
+  assert.equal(node.calls[0].paramsLen, 40)
+  assert.equal(ops[1], 'get', 'GET-back gate second')
+  assert.equal(node.calls[1].id, ADDRESSING.snapshotId(SELF, 3))
+  assert.equal(ops[2], 'publish', 'head PUT third')
+  assert.equal(node.calls[2].wasmPath, CONTRACTS.paths.object)
+  assert.equal(node.calls[2].paramsLen, 32)
+  // Everything after the head belongs to the poke phase.
+  assert.ok(node.calls.slice(3).some(c => c.op === 'update'))
+  assert.equal(report.failed, 0)
+})
+
+test('aborts before ANY poke when the snapshot does not GET back', async () => {
+  const env = envelope()
+  const node = fakeNode() // holds nothing — GET-back misses
+  await assert.rejects(() => run(env, node), (err) => {
+    assert.match(err.message, /snapshot/i)
+    assert.match(err.message, /poke/i, 'explains why we stop here')
+    return true
+  })
+  assert.equal(node.calls.filter(c => c.op === 'update').length, 0, 'no poke was sent')
+  assert.equal(node.calls.filter(c => c.op === 'publish').length, 1, 'head was never published')
+})
+
+test('aborts when the network snapshot carries a different signature', async () => {
+  const env = envelope()
+  const node = nodeWithSnapshot(env)
+  node.present.set(ADDRESSING.snapshotId(SELF, 3), { ...env, signature: 'SIG-SOMEONE-ELSE' })
+  await assert.rejects(() => run(env, node), (err) => {
+    assert.match(err.message, /signature|different signed object/i)
+    return true
+  })
+  assert.equal(node.calls.filter(c => c.op === 'update').length, 0)
+})
+
+test('an unsigned envelope is refused before the node is touched', async () => {
+  const node = fakeNode()
+  const unsigned = envelope()
+  delete unsigned.signature
+  await assert.rejects(() => run(unsigned, node), /signature/i)
+  assert.equal(node.calls.length, 0)
+})
+
+// ─── pokes ───────────────────────────────────────────────────────
+
+test('pokes every distinct relation target exactly once, self-poke included', async () => {
+  const env = envelope({
+    relations: {
+      root: [{ ref: ROOT }],
+      author: [{ ref: SELF }],       // self-poke
+      mentions: [{ ref: ROOT }],     // duplicate target, one poke
+      provenance: [{ ref: AUTHOR }],
+    },
+  })
+  const node = nodeWithSnapshot(env)
+  const report = await run(env, node)
+
+  const poked = node.calls.filter(c => c.op === 'update').map(c => c.id)
+  assert.equal(poked.length, 3)
+  assert.deepEqual(
+    new Set(poked),
+    new Set([ROOT, SELF, AUTHOR].map(r => ADDRESSING.indexId(r))),
+  )
+  assert.equal(report.pokes.length, 3)
+  assert.equal(report.failed, 0)
+})
+
+test('the poke payload is exactly one source at its revision', async () => {
+  const env = envelope({ relations: { root: [{ ref: ROOT }] } })
+  const node = nodeWithSnapshot(env)
+  await run(env, node)
+  const poke = node.calls.find(c => c.op === 'update')
+  assert.deepEqual(poke.payload, { v: 1, poke: { source_ref: SELF, revision: 3 } })
+})
+
+test('an object with no relations publishes cleanly and pokes nothing', async () => {
+  const env = envelope({ relations: {} })
+  const node = nodeWithSnapshot(env)
+  const report = await run(env, node)
+  assert.equal(report.pokes.length, 0)
+  assert.equal(report.failed, 0)
+  assert.equal(node.calls.filter(c => c.op === 'update').length, 0)
+})
+
+test('a missing revision is treated as revision 0', async () => {
+  const env = envelope({ revision: undefined, relations: {} })
+  delete env.item.revision
+  const node = fakeNode()
+  node.present.set(ADDRESSING.snapshotId(SELF, 0), env)
+  const report = await run(env, node)
+  assert.equal(report.revision, 0)
+  assert.equal(report.snapshotId, ADDRESSING.snapshotId(SELF, 0))
+})
+
+// ─── DEV-2 index-existence handling ──────────────────────────────
+
+test('DEV-2: a probe hit skips the index publish entirely', async () => {
+  const env = envelope({ relations: { root: [{ ref: ROOT }] } })
+  const node = nodeWithSnapshot(env, [ADDRESSING.indexId(ROOT)])
+  const report = await run(env, node)
+
+  assert.ok(node.calls.some(c => c.op === 'probe' && c.id === ADDRESSING.indexId(ROOT)))
+  // A re-publish round-trips ring placement and fails spuriously when the
+  // index's neighbourhood is unreachable — so a local hit must not re-publish.
+  assert.equal(
+    node.calls.filter(c => c.op === 'publish' && c.wasmPath === CONTRACTS.paths.index).length,
+    0,
+  )
+  assert.equal(report.pokes[0].created, false)
+})
+
+test('DEV-2: a probe miss publishes the empty index, then pokes', async () => {
+  const env = envelope({ relations: { root: [{ ref: ROOT }] } })
+  const node = nodeWithSnapshot(env)
+  const report = await run(env, node)
+
+  const idx = node.calls.findIndex(c => c.op === 'publish' && c.wasmPath === CONTRACTS.paths.index)
+  const upd = node.calls.findIndex(c => c.op === 'update')
+  assert.ok(idx !== -1, 'empty index was created')
+  assert.deepEqual(node.calls[idx].state, { v: 1, slots: {} })
+  assert.equal(node.calls[idx].paramsLen, 32, "index uses the TARGET's 32-byte params")
+  assert.ok(idx < upd, 'creation precedes the poke')
+  assert.equal(report.pokes[0].created, true)
+})
+
+// ─── partial failure ─────────────────────────────────────────────
+
+test('one failed poke does not stop the rest, and is reported per target', async () => {
+  const env = envelope({
+    relations: { root: [{ ref: ROOT }], author: [{ ref: SELF }], p: [{ ref: AUTHOR }] },
+  })
+  const node = nodeWithSnapshot(env)
+  const badId = ADDRESSING.indexId(SELF)
+  const failing = fakeNode({ present: node.present, fail: { update: (id) => (id === badId ? new Error('UPDATE rejected: InvalidUpdateWithInfo') : null) } })
+
+  const report = await publishObject({
+    envelope: env, node: failing, addressing: ADDRESSING, contracts: CONTRACTS, log: () => {},
+  })
+
+  assert.equal(report.pokes.length, 3)
+  assert.equal(report.failed, 1)
+  const failed = report.pokes.find(p => !p.ok)
+  assert.equal(failed.target, SELF)
+  assert.match(failed.error, /InvalidUpdateWithInfo/)
+  assert.equal(report.pokes.filter(p => p.ok).length, 2, 'the other two still went out')
+})
+
+test('a malformed relation target is a reported poke failure, not a crash', async () => {
+  const env = envelope({ relations: { broken: [{ ref: 'not-a-ref' }], root: [{ ref: ROOT }] } })
+  const node = nodeWithSnapshot(env)
+  const report = await run(env, node)
+
+  assert.equal(report.failed, 1)
+  const bad = report.pokes.find(p => p.target === 'not-a-ref')
+  assert.equal(bad.ok, false)
+  assert.match(bad.error, /ref/i)
+  assert.ok(report.pokes.find(p => p.target === ROOT).ok, 'the valid target was still poked')
+})
+
+test('a failed head PUT aborts before poking', async () => {
+  const env = envelope()
+  const node = fakeNode({
+    present: nodeWithSnapshot(env).present,
+    fail: { publish: (wasmPath) => (wasmPath === CONTRACTS.paths.object ? new Error('PUT timed out') : null) },
+  })
+  await assert.rejects(() => run(env, node), /PUT timed out/)
+  assert.equal(node.calls.filter(c => c.op === 'update').length, 0)
+})
+
+test('relation entries without a usable ref are ignored, not poked', async () => {
+  const env = envelope({
+    relations: {
+      root: [{ ref: ROOT }],
+      junk: [{ url: 'https://example.com' }, {}, { ref: 42 }],
+      empty: [],
+    },
+  })
+  const node = nodeWithSnapshot(env)
+  const report = await run(env, node)
+  assert.equal(report.pokes.length, 1)
+  assert.equal(report.pokes[0].target, ROOT)
+})
+
+test('re-running makes the identical set of node calls — the flow is idempotent', async () => {
+  const env = envelope({ relations: { root: [{ ref: ROOT }] } })
+  const first = nodeWithSnapshot(env)
+  await run(env, first)
+
+  // Second run against a node that now also holds the index.
+  const second = nodeWithSnapshot(env, [ADDRESSING.indexId(ROOT)])
+  const report = await run(env, second)
+
+  assert.equal(report.failed, 0)
+  assert.deepEqual(
+    second.calls.filter(c => c.op === 'update').map(c => c.payload),
+    first.calls.filter(c => c.op === 'update').map(c => c.payload),
+    'the same poke is re-sent; the contract merges it LWW',
+  )
+})

--- a/test/freenet-verify.test.js
+++ b/test/freenet-verify.test.js
@@ -251,3 +251,29 @@ test('D2 bounds are mirrored: the expected relation list truncates at 64', async
   }))
   assert.equal(report.slots[0].status, 'verified-current')
 })
+
+test('the 128-char bound counts code points, exactly as the contract does', async () => {
+  // The contract uses Rust's name.chars().count() — Unicode scalar values.
+  // JS .length counts UTF-16 code units, so 100 non-BMP characters measure
+  // 200 there and the name would be wrongly dropped from the expectation,
+  // failing a slot the contract legitimately wrote.
+  const name = '😀'.repeat(100) // 100 code points, 200 UTF-16 units
+  const env = sourceEnvelope({ relations: { [name]: [{ ref: TARGET }], root: [{ ref: TARGET }] } })
+  const report = await run(fakeNode({
+    index: { v: 1, slots: { [SOURCE]: { revision: 3, relations: [name, 'root'].sort() } } },
+    snapshots: { [`${SOURCE}@3`]: env },
+    heads: { [SOURCE]: env },
+  }))
+  assert.equal(report.slots[0].status, 'verified-current')
+})
+
+test('a name beyond 128 code points is dropped, as the contract drops it', async () => {
+  const tooLong = 'é'.repeat(129)
+  const env = sourceEnvelope({ relations: { [tooLong]: [{ ref: TARGET }], root: [{ ref: TARGET }] } })
+  const report = await run(fakeNode({
+    index: { v: 1, slots: { [SOURCE]: { revision: 3, relations: ['root'] } } },
+    snapshots: { [`${SOURCE}@3`]: env },
+    heads: { [SOURCE]: env },
+  }))
+  assert.equal(report.slots[0].status, 'verified-current')
+})

--- a/test/freenet-verify.test.js
+++ b/test/freenet-verify.test.js
@@ -209,3 +209,45 @@ test('a slot key that is not a parseable ref is unverified, not a crash', async 
   assert.match(report.slots[0].detail, /ref/i)
   assert.equal(report.ok, false)
 })
+
+// ─── ref canonicalisation and D2 slot bounds ─────────────────────
+
+test('an uppercase uuid in the queried ref still matches the signed relations', async () => {
+  // objectParams is uuid-case-insensitive, so an uppercase ref reaches the
+  // right index; the relation comparison must agree, or every slot would
+  // read as unverified purely because of how the ref was typed.
+  const [pk, uuid] = TARGET.split('.')
+  const upper = `${pk}.${uuid.toUpperCase()}`
+  const env = sourceEnvelope()
+  const node = fakeNode({
+    index: { v: 1, slots: { [SOURCE]: { revision: 3, relations: ['root'] } } },
+    snapshots: { [`${SOURCE}@3`]: env },
+    heads: { [SOURCE]: env },
+  })
+  const report = await verifyIndex({ ref: upper, node, addressing: ADDRESSING, log: () => {} })
+  assert.equal(report.slots[0].status, 'verified-current')
+})
+
+test('D2 bounds are mirrored: over-long relation names are not expected in a slot', async () => {
+  const longName = 'x'.repeat(129) // > 128 chars: the contract drops it
+  const env = sourceEnvelope({ relations: { root: [{ ref: TARGET }], [longName]: [{ ref: TARGET }] } })
+  const report = await run(fakeNode({
+    index: { v: 1, slots: { [SOURCE]: { revision: 3, relations: ['root'] } } },
+    snapshots: { [`${SOURCE}@3`]: env },
+    heads: { [SOURCE]: env },
+  }))
+  assert.equal(report.slots[0].status, 'verified-current')
+})
+
+test('D2 bounds are mirrored: the expected relation list truncates at 64', async () => {
+  const relations = {}
+  for (let i = 0; i < 70; i++) relations[`rel${String(i).padStart(3, '0')}`] = [{ ref: TARGET }]
+  const env = sourceEnvelope({ relations })
+  const expected = Object.keys(relations).sort().slice(0, 64)
+  const report = await run(fakeNode({
+    index: { v: 1, slots: { [SOURCE]: { revision: 3, relations: expected } } },
+    snapshots: { [`${SOURCE}@3`]: env },
+    heads: { [SOURCE]: env },
+  }))
+  assert.equal(report.slots[0].status, 'verified-current')
+})

--- a/test/freenet-verify.test.js
+++ b/test/freenet-verify.test.js
@@ -277,3 +277,23 @@ test('a name beyond 128 code points is dropped, as the contract drops it', async
   }))
   assert.equal(report.slots[0].status, 'verified-current')
 })
+
+test('relation names sort in UTF-8 byte order, as Rust String ordering does', async () => {
+  // Rust compares strings by UTF-8 bytes (== code point order). JS's default
+  // sort compares UTF-16 code units, which disagree above U+E000: a non-BMP
+  // character is a surrogate pair starting 0xD800, so it sorts BEFORE U+E000
+  // in JS and AFTER it in Rust. Get this wrong and the expected list is in a
+  // different order from the slot the contract wrote, failing an honest slot.
+  const pua = ''
+  const emoji = '\u{1F600}'
+  assert.deepEqual([emoji, pua].sort(), [emoji, pua], 'JS default order, for contrast')
+
+  const env = sourceEnvelope({ relations: { [pua]: [{ ref: TARGET }], [emoji]: [{ ref: TARGET }] } })
+  const report = await run(fakeNode({
+    // The order the contract writes: UTF-8 bytes, so U+E000 comes first.
+    index: { v: 1, slots: { [SOURCE]: { revision: 3, relations: [pua, emoji] } } },
+    snapshots: { [`${SOURCE}@3`]: env },
+    heads: { [SOURCE]: env },
+  }))
+  assert.equal(report.slots[0].status, 'verified-current')
+})

--- a/test/freenet-verify.test.js
+++ b/test/freenet-verify.test.js
@@ -1,0 +1,211 @@
+/**
+ * US-3.4 reader-side index verification, against a fake node.
+ *
+ * The index is a FILTER, NOT PROOF — the contract's creation/seeding paths
+ * accept structure-only states ("door 2"), so a slot on its own is a claim.
+ * Verification re-derives what each slot should say from the source's own
+ * signed snapshot, which is the ground truth, and only then asks whether the
+ * source has moved on.
+ */
+
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { verifyIndex } from '../src/freenet/verify.js'
+import { createAddressing } from '../src/freenet/addressing.js'
+
+const fromHex = (hex) => Uint8Array.from(hex.match(/../g).map(h => parseInt(h, 16)))
+
+const ADDRESSING = createAddressing({
+  object: fromHex('6631a15614c55e96d5297c459461bbb63ec47fd7a4fa6050e2cf104815ed3ff0'),
+  snapshot: fromHex('f2e5cf0d8f7ddd588fd2edd782e224bb146593ec0910b8d1dd0635e161c92c44'),
+  index: fromHex('27d3ea150dd78b093b0afcc2b62b43147690a2da1b0e9f5e3ea71c8b4a6c6568'),
+})
+
+const PK = 'ApWJVWXvVKIIMnH6CP6u8HUyU2gLvyYGnwRlgrWAUwcP'
+const OTHER = 'AxyU5_5vWmP2tO_klN4UpbZzRsuJEvJTrdwdg_gODxZJ'
+const TARGET = `${OTHER}.00000000-0000-0000-0000-000000000000`
+const SOURCE = `${PK}.00000000-0000-0000-0000-000000000001`
+
+function sourceEnvelope({ revision = 3, relations } = {}) {
+  return {
+    item: {
+      pubkey: PK,
+      id: '00000000-0000-0000-0000-000000000001',
+      revision,
+      relations: relations ?? { root: [{ ref: TARGET }] },
+    },
+    signature: 'SIG',
+  }
+}
+
+/** Build a node holding an index plus whatever snapshots/heads are given. */
+function fakeNode({ index, snapshots = {}, heads = {} }) {
+  const present = new Map()
+  if (index !== undefined) present.set(ADDRESSING.indexId(TARGET), index)
+  for (const [key, env] of Object.entries(snapshots)) {
+    const [ref, rev] = key.split('@')
+    present.set(ADDRESSING.snapshotId(ref, Number(rev)), env)
+  }
+  for (const [ref, env] of Object.entries(heads)) present.set(ADDRESSING.headId(ref), env)
+  return {
+    async get(id) {
+      return present.has(id)
+        ? { found: true, state: present.get(id), timedOut: false, detail: '' }
+        : { found: false, state: null, timedOut: false, detail: 'not found' }
+    },
+  }
+}
+
+const run = (node) => verifyIndex({ ref: TARGET, node, addressing: ADDRESSING, log: () => {} })
+
+test('a slot backed by its snapshot, with the head still there, is verified-current', async () => {
+  const env = sourceEnvelope()
+  const report = await run(fakeNode({
+    index: { v: 1, slots: { [SOURCE]: { revision: 3, relations: ['root'] } } },
+    snapshots: { [`${SOURCE}@3`]: env },
+    heads: { [SOURCE]: env },
+  }))
+
+  assert.equal(report.slots.length, 1)
+  assert.equal(report.slots[0].status, 'verified-current')
+  assert.equal(report.slots[0].source, SOURCE)
+  assert.equal(report.unverified, 0)
+  assert.equal(report.ok, true)
+})
+
+test('a source whose head has moved on is verified-stale, naming the head revision', async () => {
+  const report = await run(fakeNode({
+    index: { v: 1, slots: { [SOURCE]: { revision: 3, relations: ['root'] } } },
+    snapshots: { [`${SOURCE}@3`]: sourceEnvelope({ revision: 3 }) },
+    heads: { [SOURCE]: sourceEnvelope({ revision: 7 }) },
+  }))
+  assert.equal(report.slots[0].status, 'verified-stale')
+  assert.match(report.slots[0].detail, /head is at 7/)
+  assert.equal(report.unverified, 0)
+  assert.equal(report.ok, true, 'stale is an honest, verified state')
+})
+
+test('D6: no head on the node is verified-stale with currency explicitly unknown', async () => {
+  const report = await run(fakeNode({
+    index: { v: 1, slots: { [SOURCE]: { revision: 3, relations: ['root'] } } },
+    snapshots: { [`${SOURCE}@3`]: sourceEnvelope() },
+    // no head
+  }))
+  assert.equal(report.slots[0].status, 'verified-stale')
+  assert.match(report.slots[0].detail, /currency unknown/i)
+  assert.equal(report.ok, true)
+})
+
+test('a slot whose snapshot is missing is unverified', async () => {
+  const report = await run(fakeNode({
+    index: { v: 1, slots: { [SOURCE]: { revision: 3, relations: ['root'] } } },
+  }))
+  assert.equal(report.slots[0].status, 'unverified')
+  assert.match(report.slots[0].detail, /snapshot/i)
+  assert.equal(report.unverified, 1)
+  assert.equal(report.ok, false)
+})
+
+test('a slot the snapshot contradicts is unverified — the door-2 case', async () => {
+  const report = await run(fakeNode({
+    // The slot claims two relations; the snapshot only proves `root`.
+    index: { v: 1, slots: { [SOURCE]: { revision: 3, relations: ['author', 'root'] } } },
+    snapshots: { [`${SOURCE}@3`]: sourceEnvelope({ relations: { root: [{ ref: TARGET }] } }) },
+    heads: { [SOURCE]: sourceEnvelope() },
+  }))
+  assert.equal(report.slots[0].status, 'unverified')
+  assert.match(report.slots[0].detail, /disagree|expected/i)
+  assert.equal(report.ok, false)
+})
+
+test('a slot claiming the wrong revision is unverified', async () => {
+  const report = await run(fakeNode({
+    index: { v: 1, slots: { [SOURCE]: { revision: 3, relations: ['root'] } } },
+    // The snapshot at that address carries a different revision internally.
+    snapshots: { [`${SOURCE}@3`]: sourceEnvelope({ revision: 4 }) },
+    heads: { [SOURCE]: sourceEnvelope({ revision: 4 }) },
+  }))
+  assert.equal(report.slots[0].status, 'unverified')
+  assert.equal(report.ok, false)
+})
+
+test('only relations that actually point at the target are expected', async () => {
+  // The source has three relations; just two target us. `type_def` must not
+  // leak into an index it does not point at.
+  const env = sourceEnvelope({
+    relations: {
+      root: [{ ref: TARGET }],
+      author: [{ ref: TARGET }],
+      type_def: [{ ref: `${OTHER}.ba52a919-af7f-460d-9606-6efb284ad9ae` }],
+    },
+  })
+  const report = await run(fakeNode({
+    index: { v: 1, slots: { [SOURCE]: { revision: 3, relations: ['author', 'root'] } } },
+    snapshots: { [`${SOURCE}@3`]: env },
+    heads: { [SOURCE]: env },
+  }))
+  assert.equal(report.slots[0].status, 'verified-current')
+})
+
+test('expected relation names are compared sorted, not in envelope order', async () => {
+  const env = sourceEnvelope({
+    relations: { zeta: [{ ref: TARGET }], alpha: [{ ref: TARGET }] },
+  })
+  const report = await run(fakeNode({
+    index: { v: 1, slots: { [SOURCE]: { revision: 3, relations: ['alpha', 'zeta'] } } },
+    snapshots: { [`${SOURCE}@3`]: env },
+    heads: { [SOURCE]: env },
+  }))
+  assert.equal(report.slots[0].status, 'verified-current')
+})
+
+test('an index with no slots verifies vacuously', async () => {
+  const report = await run(fakeNode({ index: { v: 1, slots: {} } }))
+  assert.equal(report.slots.length, 0)
+  assert.equal(report.unverified, 0)
+  assert.equal(report.ok, true)
+})
+
+test('a missing index is an error, distinct from an empty one', async () => {
+  await assert.rejects(() => run(fakeNode({})), (err) => {
+    assert.match(err.message, /index/i)
+    assert.match(err.message, /poked|not exist|no publish/i)
+    return true
+  })
+})
+
+test('every slot is judged; one bad slot does not mask the good ones', async () => {
+  const other = `${OTHER}.346bef5e-94ff-4f7a-bcf6-d78ae1e1541c`
+  const goodEnv = sourceEnvelope()
+  const otherEnv = {
+    item: { pubkey: OTHER, id: '346bef5e-94ff-4f7a-bcf6-d78ae1e1541c', revision: 8, relations: { root: [{ ref: TARGET }] } },
+    signature: 'SIG2',
+  }
+  const report = await run(fakeNode({
+    index: {
+      v: 1,
+      slots: {
+        [SOURCE]: { revision: 3, relations: ['root'] },
+        [other]: { revision: 8, relations: ['root'] },
+      },
+    },
+    snapshots: { [`${SOURCE}@3`]: goodEnv }, // `other`'s snapshot is missing
+    heads: { [SOURCE]: goodEnv },
+  }))
+
+  assert.equal(report.slots.length, 2)
+  assert.equal(report.unverified, 1)
+  assert.equal(report.slots.find(s => s.source === SOURCE).status, 'verified-current')
+  assert.equal(report.slots.find(s => s.source === other).status, 'unverified')
+  assert.equal(report.ok, false)
+})
+
+test('a slot key that is not a parseable ref is unverified, not a crash', async () => {
+  const report = await run(fakeNode({
+    index: { v: 1, slots: { 'garbage-key': { revision: 1, relations: [] } } },
+  }))
+  assert.equal(report.slots[0].status, 'unverified')
+  assert.match(report.slots[0].detail, /ref/i)
+  assert.equal(report.ok, false)
+})


### PR DESCRIPTION
**Draft** — work stream 2 of 3 of the freenet-backend project. Adds an `ig freenet` command family that publishes dataverse objects to Freenet and reads the new inbound-relations index.

## Command surface

```
ig freenet publish <ref>           ordered publish + poke every relation target
ig freenet get <ref> [--rev N]     head, or one immutable revision
ig freenet inbound <ref>           the inbound-relations slot map (JSON)
ig freenet verify <ref>            check each slot against its snapshot
ig freenet derive <ref> [--rev N]  derived contract ids; contacts nothing
ig freenet config [<key> <value>]  show or set configuration
```

Output discipline so the commands compose with `jq`: **stdout is the payload only** (envelope JSON, slot map, derived ids); progress, diagnostics and the per-target report go to stderr. Exit 0 on success, 1 on failure — including a publish where any poke failed or the head was not confirmed, and a verify where any slot is unverified.

Config keys, stored like every other `ig` setting (one flat file under `<configDir>/config/`): `freenet-port` (default 7509), `freenet-fdev` (default `fdev` on PATH), `freenet-contracts-dir` (**required** — no honest default). Flags override config. Unconfigured commands fail with a message naming both the config key and the flag.

## Addressing model

A ref determines, with no index and no lookup, where everything about that object lives:

```
params32    = BLAKE3(pubkey_raw_33B)[..16] ‖ uuid_16B
params40    = params32 ‖ revision_be64
contract_id = base58( BLAKE3( BLAKE3(wasm_bytes) ‖ params ) )
```

| contract | WASM | params | nature |
|---|---|---|---|
| head | `dataverse_object.wasm` | 32 | mutable, LWW on revision |
| snapshot | `dataverse_object_rev.wasm` | 40 | immutable, one per `(ref, revision)` |
| index | `dataverse_inbound_index.wasm` | 32 **of the target** | who points at this object |

The WASM hashes into the id, which is what keeps the three keyspaces apart despite all deriving from the same ref. Those bytes therefore **are** the keyspace — a rebuilt contract addresses a different, empty universe and every existing object silently reads as unpublished. Hence pinned artifacts read from a configured directory, never built on the fly.

## The publish flow (US-3.1) and DEV-2

1. snapshot PUT `(ref, rev)`
2. **snapshot GET-back gate** — aborts before *any* poke
3. head PUT, with a GET-back confirmation
4. one poke per distinct relation target

The order is load-bearing. A poke makes the target's index `requires()` the source's snapshot, so poking before that snapshot is confirmed stalls each poke for the node's ~240 s fetch budget and then fails. Step 2 is cheap insurance against paying that once per target. Both GET-backs compare by **signature**, never bytes — the signature is over the canonical item, so two serializations of the same signed object are the same object.

**DEV-2** is implemented with its reasoning intact: before poking, probe the index's *local* presence with a 5 s-bounded GET, and only publish the empty index on a miss. A re-publish round-trips ring placement, which fails spuriously when the index's neighbourhood is unreachable and kills a poke that would otherwise have succeeded (observed live 2026-06-12).

Everything is idempotent — snapshot re-PUT is a no-op, head merge is LWW, pokes are LWW — so a partial run converges on re-run. Pokes are independent; one failure never stops the rest.

## Beyond the brief: US-2.4 relation removal

Publishing only the *current* targets leaves the index **permanently wrong** after a relation is removed: if rev N linked X and rev N+1 drops it, X is never told, keeps advertising the dead relation forever, and `verify` reports it `verified-current` because the slot still matches the rev-N snapshot it was built from. Silent, permanent, and invisible to the tool meant to catch exactly this. The reference shell flow has the same gap.

So `publish` now reads the previous head (bounded probe, before the head PUT overwrites it) and pokes the union of current and dropped targets. The index then fetches the new snapshot, finds no relation to itself, and writes `{revision: N+1, relations: []}` — the tombstone US-2.4 specifies. Only a *strictly older* head counts as a predecessor.

Verified live against the real contract: `{revision: 0, relations: ["mentions"]}` → `{revision: 1, relations: []}`.

## Test evidence

**375 unit/integration tests, all green** (main is at 268). None touch a Freenet node.

- **BLAKE3** against the **official** BLAKE3 test vectors — 23 cases spanning empty, sub-block, exact block, chunk boundaries (1023/1024/1025) and multi-level merkle trees to 102400 bytes.
- **Addressing** against **live-verified golden ids** — contracts actually published during the spike, and what `fdev execute get-contract-id` derives. The 16-byte owner address is separately checked against the Rust `derive-params` output, so a JS mistake can't hide behind a self-consistent chain.
- **Flows** against a fake node: call ordering, abort-before-poke on both snapshot failure modes, DEV-2 both arms, tombstones, partial-failure reporting.
- **CLI** end-to-end against a real local store and a fake `fdev` (`test-support/fake-fdev.js`): argv, stdout/stderr split, exit codes.

**Live e2e: 10/10** against a fresh local-mode node (freenet 0.2.112, fdev 0.3.274) on an isolated port/config/data dir. Opt-in via `IG_FREENET_E2E_CONTRACTS` + `IG_FREENET_E2E_PORT`; skipped otherwise, so `npm test` is unaffected. It signs its own throwaway objects, so it needs nobody's private store.

Also run by hand against the spike's three objects, reproducing its recorded end state exactly:

| check | result |
|---|---|
| derive (identity rev 3) | head `DWzw99Gt…`, index `FQ6Qbh6Y…`, snapshot `7GHNZLEQ…` ✓ |
| derive (root rev 41) | snapshot `ExUAkBcv…` ✓ |
| publish | identity 3/3 pokes (incl. self-poke) · root 6/6 · author346 3/3 |
| `inbound` root | `{identity: {3,[root]}, 346bef5e: {8,[root]}}` — headline US-3.5 |
| `inbound` identity | `{itself: {3,[author]}}` — self-poke |
| `inbound` 346bef5e | `{root: {41,[author]}}` — "the author's index lists the root" |
| `verify` × 3 | `verified-current` on every slot, exit 0 |
| re-run publish | 3/3, no index re-published (DEV-2 hit), index state byte-identical (`cmp` clean) |
| `get --rev 40` | exit 1, empty stdout — no head fallback |

Because the index slots are written by the *contract* from the snapshot it fetched and re-invoked with, a passing `inbound` assertion is evidence the two-phase `requires()` merge ran — not just that our JSON round-tripped.

## Review

`codex exec --model gpt-5.6-sol` over `git diff main...HEAD`, **4 iterations → VERDICT: APPROVED**. It found real bugs; the interesting ones:

1. **Relation removal never propagated** (the US-2.4 gap above).
2. **An unreachable node read as "contract not found"** — so a dead port didn't report a dead port, and DEV-2 would start *creating* indexes on a node it couldn't talk to. fdev's two outcomes are distinguishable and now are (`missing contract:` vs `failed to connect`). Also: `execFile` reports spawn failures with a string code, so an fdev that exists but isn't executable (EACCES) fell through as a miss.
3. **A publish whose head never landed still exited 0** — the code already detected it and the exit status ignored it.
4. **Verify didn't mirror the contract's own matching rules.** Settled by reading the contract rather than guessing: it compares refs by *derived bytes*, bounds names by Rust `chars().count()` (code points, not UTF-16 units), and sorts by UTF-8 bytes (which diverges from JS's default sort above U+E000). Each mismatch would report an honest slot as an unverifiable door-2 artifact.

One finding was **declined**: hashing the pinned WASMs into private temp copies to close a TOCTOU with `fdev` reopening them. An attacker who can rewrite your local contracts directory mid-run can rewrite it before the run, so the window grants no capability, while copying ~800 KiB per invocation is a real cost. The pinned-hash e2e assertion is the control that actually catches a swapped WASM.

## Decision to review: zero dependencies

`instructiongraph-js` today has **no runtime dependencies at all**, and ships to npm as a library. Taking `@noble/hashes` for BLAKE3 would push a transitive dependency onto every consumer for a feature most never touch — so BLAKE3 and base58 are vendored in `src/freenet/`, headed as vendored (origin, licence position, "do not hand-edit") and proven against official vectors. Neither is security-critical: they derive *addresses*, not signatures. **Signing is untouched** and stays on Web Crypto.

This is deliberately reversible: the only export used outside the module is `blake3(Uint8Array) -> Uint8Array`, so swapping to `@noble/hashes` is a one-line change if you'd rather take the dependency.

## Open questions

- **Contracts directory has no default.** Work stream 1 is pinning the WASMs into `freenet/artifacts/`; that path didn't exist yet, so the key is required rather than defaulted. Worth defaulting once WS1 lands.
- **Tombstones need the previous head to be readable.** The probe is bounded at 5 s, so if the previous head isn't on the node the removal doesn't propagate on that run. Fine for the publishing node (it published the predecessor) and it re-converges on a later publish, but it is best-effort by design.
- **`--rev` is capped at `Number.MAX_SAFE_INTEGER`,** not the full u64 range, since revisions arrive as JSON numbers. Out-of-range values are rejected loudly rather than silently truncated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
