### PR TITLE
feat(cli): `ig update <ref> <patch.json>` — partial patches instead of full replaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,8 @@ ig search [--type T] [--by PK]  # Search objects
 ig inbound <ref> [--relation R]  # Inbound relations
 ig verify <file.json>            # Verify signature
 ig sign <spec.json>              # Sign spec, print envelope
-ig create <spec.json>            # Sign and publish
+ig create <spec.json>            # Sign and publish (--update = full replace)
+ig update <ref> <patch.json>     # Deep-merge a partial patch into an object
 ig auth                          # Hub authentication
 ig identity                      # Show current identity
 ig identity generate [--name N]  # Generate new identity

--- a/cli/ig.js
+++ b/cli/ig.js
@@ -118,6 +118,7 @@ Commands:
   ig verify <file.json>            Verify signature
   ig sign <spec.json> [--identity N]  Sign spec, print envelope
   ig create <spec.json> [options]  Sign and publish
+  ig update <ref> <patch.json>     Deep-merge a partial patch into an object
   ig identity                      Show current identity
   ig identity generate [--name N]  Generate a new identity
                        [--project]  Use ./.instructionGraph instead of ~/
@@ -152,6 +153,37 @@ function commandUsage(command) {
     verify: `Usage: ig verify <file.json>\n\nVerify an instructionGraph001 envelope on disk.`,
     sign: `Usage: ig sign <spec.json> [--identity N]\n\nBuild and sign a spec, then print the canonical envelope JSON.\n\nFlags:\n  --identity N  Sign with identity N instead of active identity`,
     create: `Usage: ig create <spec.json> [--update] [--identity N] [--realm R] [--push] [--no-push]\n\nBuild, sign, and publish a spec to the configured store.\n\nSpec format (JSON):\n  All fields are optional. Auto-filled: id, pubkey, ref, in, created_at,\n  relations.author. Recommended:\n    type         Object type (e.g. POST, NOTE, COMMENT)\n    name         Short human-readable label\n    instruction  How agents should interpret/display this object\n    content      Free-form payload (e.g. { "title": "...", "body": "..." })\n  Other fields:\n    id           UUID (auto-generated if omitted)\n    in           Realm array (default: your active realm)\n    relations    Named arrays of { ref } links to other objects\n    rights       { license, ai_training_allowed }\n\n  The instruction field is key — it makes objects self-describing so any\n  agent (human or LLM) can understand them without external docs.\n\n  If using a type, add a type_def relation so the schema is validated:\n    "relations": { "type_def": [{ "ref": "<pubkey>.<type-uuid>" }] }\n\n  Structural objects should include a root relation for discoverability:\n    "relations": { "root": [{ "ref": "AxyU5_...00000000-...",\n      "url": "https://dataverse001.net/AxyU5_...00000000-..." }] }\n\nExample:\n  {\n    "type": "POST",\n    "name": "Hello",\n    "instruction": "A post. Display title and body.",\n    "content": { "title": "Hello!", "body": "First post!" }\n  }\n\nFlags:\n  --update      Allow updating existing objects (auto-increments revision,\n                sets updated_at). Without this, fails if object exists.\n  --identity N  Sign with identity N instead of active identity\n  --realm R     Override default realm (e.g. dataverse001, identity)\n  --push        Push to server (auto-login if needed for identity realm)\n  --no-push     Store locally only, skip server push`,
+
+    update: `Usage: ig update <ref> <patch.json> [--identity N] [--push] [--no-push]
+
+Deep-merge a partial patch into an existing object and publish the result.
+
+Unlike 'ig create --update' — which full-replaces the object from the spec, so
+every field the spec omits is DROPPED — 'ig update' carries over every field
+you do not mention. Use this for partial edits.
+
+Merge semantics:
+  - Nested objects merge recursively: patching content.meta.version leaves
+    content.title and content.meta.author alone.
+  - Arrays are replaced wholesale, never concatenated or merged element-wise.
+    Patching relations.references swaps out that one array and leaves sibling
+    relations (in_wiki, type_def, author, ...) untouched.
+  - Immutable fields are always preserved: id, ref, pubkey, created_at.
+  - revision is auto-incremented; updated_at is set to now.
+  - The result is validated against its TYPE schema (via the type_def relation)
+    before it is signed.
+
+The patch is a JSON object holding only the fields you want to change:
+  { "content": { "meta": { "version": 2 } } }
+
+A full 'ig get' envelope is also accepted and unwrapped, so you can round-trip:
+  ig get <ref> > patch.json   # edit it, then:
+  ig update <ref> patch.json
+
+Flags:
+  --identity N  Sign with identity N instead of active identity
+  --push        Require the hub push to succeed (auto-login for identity realm)
+  --no-push     Read and write the local store only, never touch the hub`,
 
     identity: `Usage: ig identity [generate|activate|list] [options]\n\nShow or manage the active identity.\n\nFlags:\n  --identity N  Show info for identity N instead of the active one\n\nSubcommands:\n  ig identity generate [--name N] [--project] [--activate]\n  ig identity activate <name>\n  ig identity list\n\nEnvironment:\n  INSTRUCTIONGRAPH_DIR  Override config directory location`,
     server: `Usage: ig server [set <url> | login | logout | remove | push]\n\nShow, configure, or remove the hub server connection.\n\nSubcommands:\n  ig server              Show current server status and auth\n  ig server set <url>    Connect to a hub server for sync\n  ig server login        Log in with your active identity\n  ig server logout       Log out from the hub\n  ig server remove       Disconnect and go offline\n  ig server push [--all]  Push local objects (default: your realms only)\n\nWithout a server, all data stays on local filesystem only.\nWith a server, objects sync between local storage and the hub.\nLogin uses your active identity (see ig identity).`,
@@ -1013,6 +1045,67 @@ async function main() {
         // Normal path: client.create handles existence check + update logic
         const ref = await ctx.client.create(spec, { allowUpdate, requirePush: forcePush })
         console.log(ref)
+      }
+      break
+    }
+
+    case 'update': {
+      validateFlags('update', args.slice(1), {
+        booleanFlags: ['no-push', 'push'],
+        valueFlags: ['identity']
+      })
+      const [rawRef, file] = positionals(args.slice(1), ['identity'])
+      if (!rawRef || !file) die('Usage: ig update <ref> <patch.json> [--identity N] [--push | --no-push]')
+
+      const noPush = args.includes('--no-push')
+      const forcePush = args.includes('--push')
+      if (forcePush && noPush) die('Cannot use both --push and --no-push')
+
+      const patchPath = resolve(file)
+      if (!existsSync(patchPath)) die(`Patch file not found: ${patchPath}`)
+      let patch
+      try {
+        patch = JSON.parse(readFileSync(patchPath, 'utf-8'))
+      } catch (e) {
+        die(`Patch file is not valid JSON (${patchPath}): ${e.message}`)
+      }
+
+      // Accept a wrapped envelope (e.g. straight from `ig get`) — merging it as-is
+      // would graft `is`/`signature`/`item` onto the object itself.
+      if (patch && patch.is === 'instructionGraph001' && patch.item && typeof patch.item === 'object') {
+        console.error('Detected wrapped envelope — unwrapping to flat patch fields.')
+        const { pubkey: _pk, ref: _ref, signature: _sig, ...inner } = patch.item
+        patch = inner
+      }
+
+      if (patch === null || typeof patch !== 'object' || Array.isArray(patch)) {
+        die(`Patch must be a JSON object of the fields to change, e.g. { "content": { "title": "New" } } (got ${Array.isArray(patch) ? 'an array' : typeof patch})`)
+      }
+
+      const identityName = flag('identity')
+      // Reading a private object and writing it back both need a hub session,
+      // and the object's realm is only known after the fetch — so authenticate
+      // up-front whenever we have an identity and a hub (as `ig git clone` does).
+      const hasIdentity = !!(identityName || resolveIdentityConfig(findConfigDir()))
+      const ctx = await makeClient({
+        identityName,
+        localOnly: noPush,
+        authenticate: hasIdentity && !noPush,
+      })
+      printStatus(ctx)
+
+      if (forcePush && !ctx.isOnline) {
+        die('Cannot push — no server configured. Run \'ig server set <url>\' first.')
+      }
+
+      const ref = rawRef.replace(/^ig::/, '')
+      try {
+        console.log(await ctx.client.update(ref, patch, { requirePush: forcePush }))
+      } catch (e) {
+        if (noPush && /not found/i.test(e.message)) {
+          die(`${e.message}\nWith --no-push only the local store is consulted; drop --no-push to fetch it from the hub.`)
+        }
+        die(e.message)
       }
       break
     }

--- a/cli/runtime.js
+++ b/cli/runtime.js
@@ -154,11 +154,14 @@ export function listIdentityNames(configDir) {
  * @param {string} [overrides.token] - Override the auth token
  * @param {boolean} [overrides.authenticate] - Authenticate with hub on connect
  * @param {boolean} [overrides.skipRealmCheck] - Disable realm filtering (--raw)
+ * @param {boolean} [overrides.localOnly] - Ignore any configured hub; filesystem store only (--no-push)
  * @returns {Promise<{client, configDir, isOnline, hubUrl, hub, store}>}
  */
 export async function openRuntime(overrides = {}) {
   const configDir = findConfigDir()
-  const hubUrl = readConfig(configDir, 'hub-url', null)  // null = no server configured
+  // localOnly (--no-push) pretends no server is configured, so reads and writes
+  // both stay on the filesystem store.
+  const hubUrl = overrides.localOnly ? null : readConfig(configDir, 'hub-url', null)  // null = no server configured
   const defaultRealm = overrides.realm || readConfig(configDir, 'default-realm', null)
   const dataDir = join(configDir, 'data')
   const hasLocal = existsSync(dataDir)
@@ -189,10 +192,10 @@ export async function openRuntime(overrides = {}) {
   // If realm is 'local', ensure data dir exists — local realm objects must never
   // go through hub-only mode, which would bypass the sync store's push guard.
   const effectiveRealm = overrides.realm || readConfig(configDir, 'default-realm', null)
-  if ((effectiveRealm === 'local' || effectiveRealm === 'server-public') && !hasLocal) {
+  if ((overrides.localOnly || effectiveRealm === 'local' || effectiveRealm === 'server-public') && !hasLocal) {
     mkdirSync(dataDir, { recursive: true })
   }
-  const hasLocalResolved = hasLocal || effectiveRealm === 'local' || effectiveRealm === 'server-public'
+  const hasLocalResolved = hasLocal || !!overrides.localOnly || effectiveRealm === 'local' || effectiveRealm === 'server-public'
 
   if (hubUrl && hasLocalResolved) {
     // Both: sync store (local primary, hub sync)

--- a/src/client.js
+++ b/src/client.js
@@ -247,7 +247,19 @@ export function createClient(opts = {}) {
 
     // ─── Update (fetch + merge + sign + publish) ───
 
-    async update(ref, patch) {
+    /**
+     * Patch an existing object: deep-merge `patch` into the current revision.
+     *
+     * Unlike client.create(spec, { allowUpdate }) which full-replaces from the
+     * spec, every field the patch omits is carried over untouched. Arrays are
+     * replaced wholesale (see deepMerge).
+     *
+     * @param {string} ref
+     * @param {object|((item: object) => object)} patch - partial fields, or a mutator callback
+     * @param {object} [opts]
+     * @param {boolean} [opts.requirePush] - fail if the hub leg of the publish did not succeed
+     */
+    async update(ref, patch, opts = {}) {
       requireIdentity()
       const current = await store.get(ref)
       if (!current?.item) throw new Error(`Object not found: ${ref}`)
@@ -277,6 +289,9 @@ export function createClient(opts = {}) {
       const signed = await client.sign(updated)
       const result = await client.publish(signed)
       if (!result.ok) throw new Error(`Publish failed: ${result.error || `status ${result.status}`}`)
+      if (opts.requirePush && result._remoteOk === false) {
+        throw new Error(`Hub push failed: ${result._remoteError || 'unknown error'}`)
+      }
       return signed.item.ref
     },
 

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -875,4 +875,234 @@ describe('CLI', () => {
       await access(localPath)
     })
   })
+
+  describe('ig update', () => {
+    const GENESIS = 'AxyU5_5vWmP2tO_klN4UpbZzRsuJEvJTrdwdg_gODxZJ'
+    const linkRef = (n) => `${GENESIS}.${String(n).repeat(8)}-${String(n).repeat(4)}-4${String(n).repeat(3)}-8${String(n).repeat(3)}-${String(n).repeat(12)}`
+
+    /** A fully-populated object: several top-level fields and two relation arrays. */
+    const richSpec = (id) => ({
+      type: 'WIKI_PAGE',
+      id,
+      in: ['dataverse001'],
+      name: 'Master index',
+      instruction: 'Display the index; follow references to reach the pages.',
+      content: { title: 'Index', body: 'body text', meta: { author: 'Alice', version: 1 } },
+      relations: {
+        in_wiki: [{ ref: linkRef(1) }],
+        references: [{ ref: linkRef(2) }, { ref: linkRef(3) }],
+      },
+    })
+
+    /** Create a rich object via `ig create` and return its ref. */
+    async function seed(slug, id) {
+      const specPath = join(projectDir, `${slug}-spec.json`)
+      await writeFile(specPath, JSON.stringify(richSpec(id)))
+      const { stdout } = await ig('create', specPath)
+      return stdout.trim().split('\n').pop()
+    }
+
+    /** Write a patch file; `patch` may be an object or raw text. */
+    async function patchFile(slug, patch) {
+      const p = join(projectDir, `${slug}-patch.json`)
+      await writeFile(p, typeof patch === 'string' ? patch : JSON.stringify(patch))
+      return p
+    }
+
+    it('merges one nested content field, leaving every other field intact', async () => {
+      const ref = await seed('upd-merge', 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa')
+      const before = stored.get(ref)
+      const p = await patchFile('upd-merge', { content: { meta: { version: 2 } } })
+
+      const { stdout } = await ig('update', ref, p)
+      assert.equal(stdout.trim().split('\n').pop(), ref, 'prints the ref')
+
+      const after = stored.get(ref)
+      assert.equal(after.item.type, 'WIKI_PAGE', 'type preserved')
+      assert.equal(after.item.name, 'Master index', 'name preserved')
+      assert.equal(after.item.instruction, before.item.instruction, 'instruction preserved')
+      assert.deepEqual(after.item.in, ['dataverse001'], 'realm preserved')
+      assert.equal(after.item.content.title, 'Index', 'sibling content field preserved')
+      assert.equal(after.item.content.body, 'body text', 'sibling content field preserved')
+      assert.equal(after.item.content.meta.author, 'Alice', 'nested sibling preserved')
+      assert.equal(after.item.content.meta.version, 2, 'patched field applied')
+      assert.equal(after.item.relations.references.length, 2, 'untouched relation array intact')
+      assert.equal(after.item.relations.in_wiki.length, 1, 'untouched relation intact')
+      assert.ok(after.item.relations.author, 'author relation intact')
+
+      assert.equal(after.item.id, before.item.id, 'id immutable')
+      assert.equal(after.item.pubkey, before.item.pubkey, 'pubkey immutable')
+      assert.equal(after.item.created_at, before.item.created_at, 'created_at immutable')
+      assert.equal(after.item.revision, 1, 'revision bumped')
+      assert.ok(after.item.updated_at, 'updated_at set')
+      assert.ok(await verify(after.item.pubkey, after.signature, after.item), 'valid signature')
+    })
+
+    it('replaces arrays wholesale, leaving sibling relations untouched', async () => {
+      const ref = await seed('upd-array', 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb')
+      const p = await patchFile('upd-array', { relations: { references: [{ ref: linkRef(9) }] } })
+
+      await ig('update', ref, p)
+
+      const after = stored.get(ref)
+      assert.equal(after.item.relations.references.length, 1, 'array replaced, not concatenated')
+      assert.equal(after.item.relations.references[0].ref, linkRef(9))
+      assert.equal(after.item.relations.in_wiki.length, 1, 'sibling relation untouched')
+      assert.ok(after.item.relations.author, 'author relation untouched')
+      assert.equal(after.item.content.title, 'Index', 'content untouched')
+    })
+
+    it('unwraps an `ig get` envelope used as a patch', async () => {
+      const ref = await seed('upd-envelope', 'cccccccc-cccc-4ccc-8ccc-cccccccccccc')
+      const envelope = structuredClone(stored.get(ref))
+      envelope.item.content.title = 'Retitled'
+      const p = await patchFile('upd-envelope', envelope)
+
+      const { stderr } = await ig('update', ref, p)
+      assert.match(stderr, /unwrapping/i, 'warns that it unwrapped the envelope')
+
+      const after = stored.get(ref)
+      assert.equal(after.item.content.title, 'Retitled')
+      assert.equal(after.item.is, undefined, 'envelope wrapper not merged into the item')
+      assert.equal(after.item.item, undefined, 'envelope wrapper not merged into the item')
+      assert.equal(after.item.revision, 1)
+    })
+
+    it('fails clearly when the patch file is missing', async () => {
+      const ref = await seed('upd-missing', 'dddddddd-dddd-4ddd-8ddd-dddddddddddd')
+      await assert.rejects(
+        ig('update', ref, join(projectDir, 'no-such-patch.json')),
+        err => /patch file not found/i.test(err.stderr)
+      )
+    })
+
+    it('fails clearly when the patch file is not valid JSON', async () => {
+      const ref = await seed('upd-bad-json', 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee')
+      const p = await patchFile('upd-bad-json', '{ "content": ')
+      await assert.rejects(
+        ig('update', ref, p),
+        err => /not valid json/i.test(err.stderr)
+      )
+    })
+
+    it('rejects a patch that is not a JSON object', async () => {
+      const ref = await seed('upd-not-object', 'ffffffff-ffff-4fff-8fff-ffffffffffff')
+      const p = await patchFile('upd-not-object', [{ content: { title: 'nope' } }])
+      await assert.rejects(
+        ig('update', ref, p),
+        err => /must be a json object/i.test(err.stderr)
+      )
+    })
+
+    it('fails when the object does not exist', async () => {
+      const p = await patchFile('upd-absent', { content: { title: 'x' } })
+      await assert.rejects(
+        ig('update', `${GENESIS}.99999999-9999-4999-8999-999999999999`, p),
+        err => /not found/i.test(err.stderr)
+      )
+    })
+
+    it("refuses to update someone else's object", async () => {
+      const ref = await seed('upd-foreign', '12121212-1212-4121-8121-121212121212')
+      const p = await patchFile('upd-foreign', { content: { title: 'hijacked' } })
+      await assert.rejects(
+        ig('update', ref, p, '--identity', 'alt'),
+        err => /only update your own objects/i.test(err.stderr)
+      )
+      assert.equal(stored.get(ref).item.content.title, 'Index', 'object unchanged')
+    })
+
+    it('requires both a ref and a patch file', async () => {
+      await assert.rejects(
+        ig('update', `${GENESIS}.99999999-9999-4999-8999-999999999999`),
+        err => /Usage: ig update/.test(err.stderr)
+      )
+    })
+
+    it('--no-push updates locally without touching the hub', async () => {
+      const freshDir = await mkdtemp(join(tmpdir(), 'ig-update-nopush-'))
+      const igDir = join(freshDir, '.instructionGraph')
+      await mkdir(join(igDir, 'config'), { recursive: true })
+      await mkdir(join(igDir, 'data'), { recursive: true })
+      await mkdir(join(igDir, 'identities', 'default'), { recursive: true })
+      await writeFile(join(igDir, 'config', 'hub-url'), hub.url)
+      await writeFile(join(igDir, 'config', 'active-identity'), 'default')
+      const pem = generateKeyPairSync('ec', { namedCurve: 'prime256v1' })
+        .privateKey.export({ format: 'pem', type: 'pkcs8' }).toString()
+      await writeFile(join(igDir, 'identities', 'default', 'private.pem'), pem)
+
+      const igFresh = (...a) => execFile('node', [CLI, ...a], {
+        cwd: freshDir,
+        env: { ...process.env, INSTRUCTIONGRAPH_DIR: igDir }
+      })
+
+      const specPath = join(freshDir, 'nopush-spec.json')
+      await writeFile(specPath, JSON.stringify({ type: 'NOTE', in: ['dataverse001'], content: { text: 'v1', keep: 'me' } }))
+      const { stdout: out1 } = await igFresh('create', specPath, '--no-push')
+      const ref = out1.trim().split('\n').pop()
+
+      const hubSizeBefore = stored.size
+      const p = join(freshDir, 'nopush-patch.json')
+      await writeFile(p, JSON.stringify({ content: { text: 'v2' } }))
+      await igFresh('update', ref, p, '--no-push')
+
+      assert.equal(stored.size, hubSizeBefore, 'hub untouched')
+      assert.equal(stored.has(ref), false, 'object never reached the hub')
+
+      const local = JSON.parse(await readFile(join(igDir, 'data', `${ref}.json`), 'utf-8'))
+      assert.equal(local.item.content.text, 'v2', 'patch applied locally')
+      assert.equal(local.item.content.keep, 'me', 'sibling field preserved')
+      assert.equal(local.item.revision, 1, 'revision bumped')
+
+      await rm(freshDir, { recursive: true })
+    })
+
+    it('--push updates a private identity-realm object on the hub', async () => {
+      const freshDir = await mkdtemp(join(tmpdir(), 'ig-update-private-'))
+      const igDir = join(freshDir, '.instructionGraph')
+      await mkdir(join(igDir, 'config'), { recursive: true })
+      await mkdir(join(igDir, 'data'), { recursive: true })
+      await mkdir(join(igDir, 'identities', 'default'), { recursive: true })
+      await writeFile(join(igDir, 'config', 'hub-url'), hub.url)
+      await writeFile(join(igDir, 'config', 'active-identity'), 'default')
+      const pem = generateKeyPairSync('ec', { namedCurve: 'prime256v1' })
+        .privateKey.export({ format: 'pem', type: 'pkcs8' }).toString()
+      await writeFile(join(igDir, 'identities', 'default', 'private.pem'), pem)
+
+      const igFresh = (...a) => execFile('node', [CLI, ...a], {
+        cwd: freshDir,
+        env: { ...process.env, INSTRUCTIONGRAPH_DIR: igDir }
+      })
+
+      // No `in` → lands in the signer's identity realm (private)
+      const specPath = join(freshDir, 'private-spec.json')
+      await writeFile(specPath, JSON.stringify({ type: 'NOTE', content: { text: 'secret v1', keep: 'me' } }))
+      const { stdout: out1 } = await igFresh('create', specPath, '--push')
+      const ref = out1.trim().split('\n').pop()
+      const pubkey = ref.split('.')[0]
+      assert.deepEqual(stored.get(ref).item.in, [pubkey], 'object is in its identity realm')
+
+      const p = join(freshDir, 'private-patch.json')
+      await writeFile(p, JSON.stringify({ content: { text: 'secret v2' } }))
+      await igFresh('update', ref, p, '--push')
+
+      const after = stored.get(ref)
+      assert.equal(after.item.content.text, 'secret v2', 'patch pushed to hub')
+      assert.equal(after.item.content.keep, 'me', 'sibling field preserved')
+      assert.equal(after.item.revision, 1, 'revision bumped')
+      assert.ok(await verify(after.item.pubkey, after.signature, after.item), 'valid signature')
+
+      await rm(freshDir, { recursive: true })
+    })
+
+    it('is documented in general and command help', async () => {
+      const { stdout: general } = await ig('--help')
+      assert.match(general, /ig update <ref> <patch\.json>/, 'listed in general usage')
+
+      const { stdout: cmdHelp } = await ig('update', '--help')
+      assert.match(cmdHelp, /Usage: ig update <ref> <patch\.json>/)
+      assert.match(cmdHelp, /deep-merge/i, 'explains deep merge')
+      assert.match(cmdHelp, /arrays are replaced/i, 'documents array replacement')
+    })
+  })
 })

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -259,6 +259,29 @@ describe('client', () => {
       assert.equal(updated.item.pubkey, ig.pubkey)
       assert.equal(updated.item.created_at, original.item.created_at)
     })
+
+    it('requirePush surfaces a failed hub push', async () => {
+      const store = createMockStore()
+      const ig = createClient({
+        store,
+        identity: { type: 'credentials', username: 'merge-test', password: 'merge-test-pw' }
+      })
+      await ig.ready
+
+      const ref = await ig.create({ type: 'POST', content: { title: 'Original' } })
+
+      // Sync store reports a failed remote leg as _remoteOk: false on an otherwise-ok put
+      const localPut = store.put
+      store.put = async (obj) => ({ ...(await localPut(obj)), _remoteOk: false, _remoteError: 'hub said no' })
+
+      await assert.rejects(
+        () => ig.update(ref, { content: { title: 'Patched' } }, { requirePush: true }),
+        /Hub push failed: hub said no/
+      )
+      // Without requirePush the local write still succeeds
+      await ig.update(ref, { content: { title: 'Patched' } })
+      assert.equal((await store.get(ref)).item.content.title, 'Patched')
+    })
   })
 
   describe('createIdentity with PEM persistence', () => {


### PR DESCRIPTION
## Why

`ig create <spec> --update` is a **full replace**, not a patch. `client.create` (`src/client.js:185`) rebuilds the revision from the spec alone, inheriting only `id`, `created_at`, `revision`, `updated_at`. Every top-level field the spec omits — `type`, `name`, `content`, `relations`, `instruction`, `in` — is dropped from revision N+1.

This caused real data loss on **2026-08-04**: a background wiki agent issued partial `--update` writes that nulled `type` on 5 pages and wiped a wiki master index's `references` relation (261 entries gone).

The failure mode is **self-concealing**: `validateType` (`src/client.js:153`) bails out early when `relations.type_def` is absent — so the very omission that drops the fields also disables the schema check that would have caught it. Until now the only control was a warning sentence in an agent prompt, i.e. model discipline. One model followed it; another did not.

The library already had correct merge semantics in `client.update()`. Nothing in the CLI reached it. **This PR wires it up.** Purely additive — `client.create` semantics are untouched.

## Usage

```
ig update <ref> <patch.json> [--identity N] [--push | --no-push]
```

```bash
# change one nested field; everything else is carried over untouched
echo '{"content":{"meta":{"version":2}}}' > patch.json
ig update <pubkey>.<uuid> patch.json
```

## Merge semantics

Deep merge via the existing `deepMerge` (`src/client.js:19`):

| | behaviour |
|---|---|
| Nested objects | merge recursively — patching `content.meta.version` leaves `content.title` and `content.meta.author` alone |
| **Arrays** | **replaced wholesale** — never concatenated or merged element-wise. Patching `relations.references` swaps out that one array and leaves `in_wiki`, `type_def`, `author`, … untouched |
| `id`, `ref`, `pubkey`, `created_at` | immutable, always preserved |
| `revision` | auto-incremented |
| `updated_at` | set to now |
| TYPE schema | `validateType()` runs on the merged result before signing |

The array rule is the desired behaviour and is spelled out explicitly in `ig update --help` so callers aren't surprised.

## Flags

Mirror `ig create`:

- `--identity N` — sign with a specific identity
- `--push` — require the hub push to succeed (auto-login for identity realms); errors if no server is configured
- `--no-push` — read **and** write the local store only, never touch the hub

**Private / identity-realm objects:** reading the current revision and writing it back both need a hub session, and the object's realm is only knowable *after* the fetch — so we authenticate up-front whenever an identity and a hub are present. Same idiom `ig git clone` / `ig git fork` already use (`authenticate: hasIdentity`). In-session auth via `openRuntime`; no token persisted to config.

## Error handling

| condition | message |
|---|---|
| patch file missing | `Patch file not found: <path>` |
| patch unparseable | `Patch file is not valid JSON (<path>): <err>` |
| patch is array/scalar/null | `Patch must be a JSON object … (got an array)` |
| object not found | `Object not found: <ref>` (+ a `--no-push`-specific hint that only the local store was consulted) |
| someone else's object | `Can only update your own objects` |
| `--push` and `--no-push` together | refused |

A full `ig get` envelope passed as the patch is detected and unwrapped (as `ig create` does) — merging it raw would graft `is`, `item` and `signature` onto the object itself. `ig::`-prefixed refs are accepted, as elsewhere in the CLI.

## Supporting changes

- `client.update(ref, patch, opts)` gains `opts.requirePush`, mirroring `client.create`. Without it, `ig update --push` to an identity realm would silently write locally and report success when the hub leg failed (the sync store's `shouldPushToRemote()` skips identity-realm pushes when unauthenticated).
- `openRuntime({ localOnly })` pretends no hub is configured, so reads and writes both stay on the fs store. `ig create --no-push` hand-rolls this with a second inline fs store; `ig update --no-push` needs the *read* local too, so the whole client has to point at local.

## Tests

TDD — 13 tests written failing first (all 13 red with `Unknown command: update`), then made green.

12 new CLI tests + 1 new client test:
- one nested content field patched → `type` / `name` / `instruction` / `in`, sibling content fields, both relation arrays and `relations.author` all intact; revision bumped; `id` / `pubkey` / `created_at` unchanged; signature verifies
- arrays replaced wholesale, sibling relations untouched
- `ig get` envelope accepted as a patch, wrapper not merged into the item
- all six error paths above
- `--no-push` updates the local copy and never reaches the hub
- `--push` round-trips a private identity-realm object through the hub
- documented in both `ig --help` and `ig update --help`
- `requirePush` surfaces a failed hub push (client level)

```
ℹ tests 281
ℹ pass 281
ℹ fail 0
```

Also verified end-to-end with the real binary in an isolated `INSTRUCTIONGRAPH_DIR`: after patching `content.meta.version`, `type` / `name` / `instruction` / `in` / `content.title` / `content.body` / `content.meta.author` and all three relations (`author`, `in_wiki`, `references` × 2) survived.

Developed in a git worktree; `main` in the primary working tree was never touched, so the live `~/.npm-global/bin/ig` symlink stayed functional throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)